### PR TITLE
feat: add Home Assistant add-on and legacy SSE transport

### DIFF
--- a/homeassistant-addon/Dockerfile
+++ b/homeassistant-addon/Dockerfile
@@ -1,0 +1,11 @@
+ARG BUILD_FROM
+FROM ${BUILD_FROM}
+
+RUN apk add --no-cache jq
+
+RUN npm install -g mcp-picnic
+
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]

--- a/homeassistant-addon/build.yaml
+++ b/homeassistant-addon/build.yaml
@@ -1,0 +1,3 @@
+build_from:
+  amd64: node:22-alpine
+  aarch64: node:22-alpine

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,0 +1,23 @@
+name: "MCP Picnic"
+version: "1.0.1"
+slug: mcp_picnic
+description: "MCP server for Picnic grocery delivery - AI-powered grocery shopping"
+url: "https://github.com/ivo-toby/mcp-picnic"
+arch:
+  - amd64
+  - aarch64
+init: false
+startup: application
+boot: auto
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: "MCP SSE server"
+options:
+  picnic_username: ""
+  picnic_password: ""
+  picnic_country_code: "NL"
+schema:
+  picnic_username: str
+  picnic_password: password
+  picnic_country_code: "list(NL|DE)"

--- a/homeassistant-addon/run.sh
+++ b/homeassistant-addon/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+CONFIG_PATH=/data/options.json
+
+export PICNIC_USERNAME=$(jq -r '.picnic_username' "$CONFIG_PATH")
+export PICNIC_PASSWORD=$(jq -r '.picnic_password' "$CONFIG_PATH")
+export PICNIC_COUNTRY_CODE=$(jq -r '.picnic_country_code' "$CONFIG_PATH")
+export HTTP_PORT=3000
+export HTTP_HOST=0.0.0.0
+export ENABLE_HTTP_SERVER=true
+
+exec node /usr/local/lib/node_modules/mcp-picnic/bin/mcp-server.js

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: MCP Picnic Add-ons
+url: "https://github.com/ivo-toby/mcp-picnic"
+maintainer: "ivo-toby"

--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -1,4 +1,5 @@
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
 import express, { Request, Response, NextFunction } from "express"
 import cors from "cors"
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
@@ -34,6 +35,7 @@ export class StreamableHttpServer extends BaseTransportServer {
   private options: StreamableHttpServerOptions
   private rateLimiter?: ReturnType<typeof createRateLimitMiddleware>
   private transports: Record<string, StreamableHTTPServerTransport> = {}
+  private sseTransports: Map<string, SSEServerTransport> = new Map()
   private sessionTimeouts = new Map<string, NodeJS.Timeout>()
 
   /**
@@ -250,6 +252,36 @@ export class StreamableHttpServer extends BaseTransportServer {
       this.cleanupSession(sessionId)
       res.status(204).send()
     })
+
+    // Legacy SSE transport endpoints for backwards compatibility (e.g. Home Assistant)
+    this.app.get("/sse", async (_req: Request, res: Response) => {
+      console.error("Received GET request to /sse (legacy SSE transport)")
+      const transport = new SSEServerTransport("/messages", res)
+      this.sseTransports.set(transport.sessionId, transport)
+
+      res.on("close", () => {
+        this.sseTransports.delete(transport.sessionId)
+      })
+
+      const server = this.createConfiguredServer()
+      await server.connect(transport)
+    })
+
+    this.app.post("/messages", async (req: Request, res: Response) => {
+      const sessionId = req.query.sessionId as string
+      const transport = this.sseTransports.get(sessionId)
+
+      if (!transport) {
+        res.status(400).json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "No transport found for sessionId" },
+          id: null,
+        })
+        return
+      }
+
+      await transport.handlePostMessage(req, res, req.body)
+    })
   }
 
   /**
@@ -350,6 +382,7 @@ export class StreamableHttpServer extends BaseTransportServer {
     return new Promise((resolve) => {
       this.server = this.app.listen(this.port, () => {
         console.error(`MCP StreamableHTTP server running on http://${this.host}:${this.port}/mcp`)
+        console.error(`MCP Legacy SSE endpoint available at http://${this.host}:${this.port}/sse`)
         resolve()
       })
 
@@ -381,6 +414,16 @@ export class StreamableHttpServer extends BaseTransportServer {
         }
       }),
     )
+
+    // Clean up SSE transports
+    for (const [sessionId, transport] of this.sseTransports) {
+      try {
+        await transport.close()
+      } catch (error) {
+        ErrorUtils.logError(error, `SSE session ${sessionId} cleanup`)
+      }
+    }
+    this.sseTransports.clear()
 
     // Clean up rate limiter
     if (this.rateLimiter) {


### PR DESCRIPTION
## Summary

- Add legacy SSE transport endpoints (`GET /sse` + `POST /messages`) to the HTTP server for backwards compatibility with clients that only support the older SSE protocol (e.g. Home Assistant's MCP integration)
- Add Home Assistant add-on configuration (`homeassistant-addon/`) so the repo can be used as an HA add-on repository
- Add `repository.yaml` for HA add-on discovery

## How to use with Home Assistant

1. Add `https://github.com/ivo-toby/mcp-picnic` as an add-on repository in HA
2. Install "MCP Picnic" add-on, enter Picnic credentials in config
3. Start the add-on
4. Add MCP integration in HA: Settings > Devices & Services > Add Integration > MCP
5. Enter SSE URL: `http://homeassistant.local:3000/sse`

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm run typecheck` passes
- [x] `npm test` — all 185 tests pass
- [ ] Test SSE endpoint locally: `curl http://localhost:3000/sse` returns SSE stream with `endpoint` event
- [ ] Build Docker image: `docker build -f homeassistant-addon/Dockerfile homeassistant-addon/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)