### PR TITLE
feat: implement session persistence for Picnic client

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ const configSchema = z.object({
     .transform((val) => parseInt(val, 10))
     .default("3000"),
   HTTP_HOST: z.string().default("localhost"),
+  PICNIC_SESSION_FILE: z.string().default("picnic-session.json"),
 })
 
 export const config = configSchema.parse(process.env)

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { toolRegistry } from "./registry.js"
-import { getPicnicClient, initializePicnicClient } from "../utils/picnic-client.js"
+import { getPicnicClient, initializePicnicClient, saveSession } from "../utils/picnic-client.js"
 
 /**
  * Picnic API tools optimized for LLM consumption
@@ -810,6 +810,7 @@ toolRegistry.register({
     await ensureClientInitialized()
     const client = getPicnicClient()
     const result = await client.verify2FACode(args.code)
+    await saveSession()
     return {
       message: "2FA code verified",
       code: args.code,

--- a/src/utils/picnic-client.ts
+++ b/src/utils/picnic-client.ts
@@ -1,8 +1,27 @@
 import PicnicClient from "picnic-api"
+import fs from "fs/promises"
 import { config } from "../config.js"
 
 // Singleton instance for caching
 let picnicClientInstance: InstanceType<typeof PicnicClient> | null = null
+
+async function loadSession(): Promise<string | null> {
+  try {
+    const data = await fs.readFile(config.PICNIC_SESSION_FILE, "utf-8")
+    const session = JSON.parse(data)
+    return session.authKey || null
+  } catch (error) {
+    return null
+  }
+}
+
+export async function saveSession(): Promise<void> {
+  if (!picnicClientInstance) return
+  const authKey = (picnicClientInstance as any).authKey
+  if (authKey) {
+    await fs.writeFile(config.PICNIC_SESSION_FILE, JSON.stringify({ authKey }))
+  }
+}
 
 export async function initializePicnicClient(
   username?: string,
@@ -19,13 +38,30 @@ export async function initializePicnicClient(
   const loginPassword = password || config.PICNIC_PASSWORD
   const loginCountryCode = countryCode || config.PICNIC_COUNTRY_CODE
 
+  const savedAuthKey = await loadSession()
+
   const client = new PicnicClient({
     countryCode: loginCountryCode,
     apiVersion,
+    authKey: savedAuthKey ?? undefined,
   })
+
+  if (savedAuthKey) {
+    try {
+      console.error("Testing saved auth key...")
+      await client.getUserInfo()
+      picnicClientInstance = client
+      console.error("Successfully reused saved session.")
+      return
+    } catch (error) {
+      console.error("Saved session invalid, performing fresh login...")
+      client.authKey = null // Clear invalid key before login
+    }
+  }
 
   await client.login(loginUsername, loginPassword)
   picnicClientInstance = client
+  await saveSession()
   console.error("Picnic client initialized successfully.")
 }
 


### PR DESCRIPTION
This PR introduces automated session management to improve the user experience and reliability of the MCP server.


  Changes:
   - Session Persistence: Added logic to src/utils/picnic-client.ts to save the authKey to a local file (picnic-session.json) after successful login or 2FA verification.
   - Automated Re-authentication: The client now attempts to load and reuse an existing session on startup. If the session is invalid or expired, it automatically falls back to a fresh login flow.
   - Configurable Storage: Added PICNIC_SESSION_FILE to the configuration schema in src/config.ts to allow users to customize the session storage path.
   - Enhanced 2FA Flow: Updated the verify2FACode tool to trigger a session save immediately upon successful verification.