### PR TITLE
ci: enable npm provenance with OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -26,6 +27,7 @@ jobs:
         with:
           node-version: "lts/*"
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -40,4 +42,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { "provenance": true }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for GitHub OIDC token generation
- Configure `registry-url` in Node.js setup step
- Add `NODE_AUTH_TOKEN` env var for npm authentication
- Enable `provenance: true` in `@semantic-release/npm` plugin config

## Setup required
- Ensure `NPM_TOKEN` secret is configured in repo settings
- Ensure workflow permissions allow "Read and write permissions" under Settings > Actions > General

## Test plan
- [ ] Verify the release workflow runs successfully on merge
- [ ] Confirm published package shows provenance on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to request OIDC tokens and publish to npm with provenance enabled, which can impact publishing permissions and release success if secrets/permissions are misconfigured.
> 
> **Overview**
> Updates the GitHub Actions release workflow to support npm publishing with provenance by granting `id-token: write`, configuring `actions/setup-node` with the npm registry URL, and exporting `NODE_AUTH_TOKEN` for authentication.
> 
> Adjusts `semantic-release` config to enable npm provenance via `@semantic-release/npm` (`provenance: true`) during publish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce47f87b97e8835255f8b2bdef8abda42ad1710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->