### PR TITLE
chore: align Picnic API integration and docs with v4.3.0

### DIFF
--- a/.minispec/knowledge/decisions/001-remove-deprecated-tools.md
+++ b/.minispec/knowledge/decisions/001-remove-deprecated-tools.md
@@ -17,6 +17,7 @@ are a different paradigm.
 ## Decision
 
 Remove the corresponding MCP tools:
+
 - `picnic_get_categories`
 - `picnic_get_category_details`
 - `picnic_get_lists`

--- a/.minispec/knowledge/decisions/003-keep-2fa-fetch-bypass.md
+++ b/.minispec/knowledge/decisions/003-keep-2fa-fetch-bypass.md
@@ -1,25 +1,25 @@
 ---
 id: "003"
-title: Keep raw fetch bypass for 2FA verification
-status: accepted
-date: 2026-03-06
+title: Use upstream 2FA verification support
+status: superseded
+date: 2026-04-19
 context: picnic-api-v4-upgrade
 ---
 
-# Keep raw fetch bypass for 2FA verification
+# Use upstream 2FA verification support
 
 ## Context
 
-`picnic_verify_2fa_code` bypasses `client.verify2FACode()` with a raw
-`fetch()` call to capture the `x-picnic-auth` response header. The
-upstream `sendRequest` does not expose response headers.
+`picnic-api` 4.0.1 updated `client.auth.verify2FACode()` to capture the
+refreshed `x-picnic-auth` token returned by Picnic after successful 2FA.
+The MCP server no longer needs a raw `fetch()` bypass to complete 2FA.
 
 ## Decision
 
-Keep the raw fetch bypass. Create a GitHub issue to revisit this after
-the upgrade (either upstream fix or local improvement).
+Replace the local raw `fetch()` bypass with `client.auth.verify2FACode()`
+and persist the refreshed session after verification.
 
 ## Rationale
 
-Safe upgrade path — changing the 2FA flow during a dependency upgrade
-adds unnecessary risk. The bypass works and is well-documented in code.
+The upstream library now handles the auth token refresh correctly, so the
+custom HTTP path is unnecessary duplication and a maintenance burden.

--- a/.minispec/knowledge/decisions/003-keep-2fa-fetch-bypass.md
+++ b/.minispec/knowledge/decisions/003-keep-2fa-fetch-bypass.md
@@ -1,25 +1,30 @@
 ---
 id: "003"
-title: Use upstream 2FA verification support
+title: Keep raw fetch bypass for 2FA verification
 status: superseded
-date: 2026-04-19
+date: 2026-03-06
 context: picnic-api-v4-upgrade
 ---
 
-# Use upstream 2FA verification support
+# Keep raw fetch bypass for 2FA verification
 
 ## Context
 
-`picnic-api` 4.0.1 updated `client.auth.verify2FACode()` to capture the
-refreshed `x-picnic-auth` token returned by Picnic after successful 2FA.
-The MCP server no longer needs a raw `fetch()` bypass to complete 2FA.
+`picnic_verify_2fa_code` bypasses `client.verify2FACode()` with a raw
+`fetch()` call to capture the `x-picnic-auth` response header. The
+upstream `sendRequest` does not expose response headers.
 
 ## Decision
 
-Replace the local raw `fetch()` bypass with `client.auth.verify2FACode()`
-and persist the refreshed session after verification.
+Keep the raw fetch bypass. Create a GitHub issue to revisit this after
+the upgrade (either upstream fix or local improvement).
 
 ## Rationale
 
-The upstream library now handles the auth token refresh correctly, so the
-custom HTTP path is unnecessary duplication and a maintenance burden.
+Safe upgrade path - changing the 2FA flow during a dependency upgrade
+adds unnecessary risk. The bypass works and is well-documented in code.
+
+## Superseded by
+
+ADR 004 replaces this decision now that upstream 2FA verification persists
+the refreshed auth token correctly.

--- a/.minispec/knowledge/decisions/004-use-upstream-2fa-verify.md
+++ b/.minispec/knowledge/decisions/004-use-upstream-2fa-verify.md
@@ -1,0 +1,26 @@
+---
+id: "004"
+title: Use upstream 2FA verification support
+status: accepted
+date: 2026-04-19
+context: picnic-api-v4-upgrade
+supersedes: "003"
+---
+
+# Use upstream 2FA verification support
+
+## Context
+
+`picnic-api` 4.0.1 updated `client.auth.verify2FACode()` to capture the
+refreshed `x-picnic-auth` token returned by Picnic after successful 2FA.
+The MCP server no longer needs a raw `fetch()` bypass to complete 2FA.
+
+## Decision
+
+Replace the local raw `fetch()` bypass with `client.auth.verify2FACode()`
+and persist the refreshed session after verification.
+
+## Rationale
+
+The upstream library now handles the auth token refresh correctly, so the
+custom HTTP path is unnecessary duplication and a maintenance burden.

--- a/.minispec/specs/picnic-api-v4-upgrade/design.md
+++ b/.minispec/specs/picnic-api-v4-upgrade/design.md
@@ -71,11 +71,11 @@ with no new features.
 v4 `HttpClient` exposes `authKey` and `url` as public properties.
 Remove `as any` casts in `picnic-client.ts` and the 2FA verify handler.
 
-## 2FA Verify Bypass
+## 2FA Verification
 
-Keep the raw `fetch()` bypass in `picnic_verify_2fa_code` — it captures
-response headers that `sendRequest` does not expose. A GitHub issue will
-be created to revisit this after upgrade.
+Use `client.auth.verify2FACode()` directly. `picnic-api` 4.0.1+
+captures the refreshed auth token from the response headers, so the MCP
+server no longer needs a custom `fetch()` bypass.
 
 ## Open Questions
 

--- a/PICNIC_TOOLS.md
+++ b/PICNIC_TOOLS.md
@@ -49,7 +49,7 @@ Look up product details by selling unit ID.
 **Parameters:**
 
 - `productId` (string): The selling unit ID to inspect
-- `full` (boolean, optional): Return full product details including description, allergens, ingredients, and similar products
+- `full` (boolean, optional): Return full product details including description, allergens, ingredients, similar products, and bundle discount pricing when available
 
 #### `picnic_get_image`
 
@@ -65,6 +65,11 @@ Get image data for a product using the image ID and size.
 #### `picnic_get_cart`
 
 Get the current shopping cart contents.
+
+**Notes:**
+
+- Includes `total_savings` when Picnic returns bundle discount savings
+- Articles may include `bundle_prices` when lower per-unit prices apply at higher quantities
 
 #### `picnic_add_to_cart`
 
@@ -87,6 +92,22 @@ Remove a product from the shopping cart.
 #### `picnic_clear_cart`
 
 Clear all items from the shopping cart.
+
+#### `picnic_send_delivery_invoice_email`
+
+Send or resend the invoice email for a completed delivery.
+
+**Parameters:**
+
+- `deliveryId` (string): The ID of the delivery to send the invoice email for
+
+#### `picnic_get_order_status`
+
+Get the status of a specific order.
+
+**Parameters:**
+
+- `orderId` (string): The ID of the order to inspect
 
 ### Delivery Management
 

--- a/PICNIC_TOOLS.md
+++ b/PICNIC_TOOLS.md
@@ -42,19 +42,23 @@ Get product suggestions based on a query.
 
 - `query` (string): Query for product suggestions
 
-#### ~~`picnic_get_article`~~ (REMOVED)
+#### `picnic_get_product_details`
 
-**This tool has been removed** because the Picnic API deprecated product detail endpoints. See [GitHub issue #23](https://github.com/MRVDH/picnic-api/issues/23).
-
-**Alternative:** Use `picnic_search` to get basic product information (id, name, price, unit).
-
-#### `picnic_get_categories`
-
-Get product categories from Picnic.
+Look up product details by selling unit ID.
 
 **Parameters:**
 
-- `depth` (number, optional): Category depth to retrieve (0-5, default: 0)
+- `productId` (string): The selling unit ID to inspect
+- `full` (boolean, optional): Return full product details including description, allergens, ingredients, and similar products
+
+#### `picnic_get_image`
+
+Get image data for a product using the image ID and size.
+
+**Parameters:**
+
+- `imageId` (string): The image ID to retrieve
+- `size` (string): One of `tiny`, `small`, `medium`, `large`, `extra-large`
 
 ### Shopping Cart Management
 
@@ -157,26 +161,6 @@ Get details of the current logged-in user.
 
 Get user information including toggled features.
 
-### Lists Management
-
-#### `picnic_get_lists`
-
-Get shopping lists and sublists.
-
-**Parameters:**
-
-- `depth` (number, optional): List depth to retrieve (0-5, default: 0)
-
-#### `picnic_get_list`
-
-Get a specific list or sublist with its items.
-
-**Parameters:**
-
-- `listId` (string): The ID of the list to get
-- `subListId` (string, optional): The ID of the sub list to get
-- `depth` (number, optional): List depth to retrieve (0-5, default: 0)
-
 ### Payment & Transactions
 
 #### `picnic_get_payment_profile`
@@ -198,12 +182,6 @@ Get detailed information about a specific wallet transaction.
 **Parameters:**
 
 - `transactionId` (string): The ID of the transaction to get details for
-
-### Other
-
-#### `picnic_get_mgm_details`
-
-Get MGM (friends discount) details.
 
 ## Usage Example
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ MCP Picnic is a bridge between AI assistants (like Claude, ChatGPT, or other MCP
 
 - 🇳🇱 Netherlands
 - 🇩🇪 Germany
-- 🇫🇷 France
 
 ## Key Features
 
@@ -47,7 +46,7 @@ MCP Picnic is a bridge between AI assistants (like Claude, ChatGPT, or other MCP
 
 ### Prerequisites
 
-- A Picnic account (available in Netherlands, Germany, or France)
+- A Picnic account (available in the Netherlands or Germany)
 - An MCP-compatible AI assistant (Claude Desktop, Continue, etc.)
 - Node.js 18+ installed on your system
 
@@ -84,7 +83,7 @@ Add this configuration:
 
 **Important**:
 - Replace `your-picnic-email@example.com` and `your-picnic-password` with your actual Picnic account credentials.
-- Set `PICNIC_COUNTRY_CODE` to `"DE"` for Germany, `"FR"` for France, or `"NL"` for the Netherlands (default).
+- Set `PICNIC_COUNTRY_CODE` to `"DE"` for Germany, or `"NL"` for the Netherlands (default).
 
 3. **Restart Claude Desktop** completely
 
@@ -148,7 +147,7 @@ User: "I want to make lasagna but need gluten-free and dairy-free alternatives"
 AI Actions:
 1. Uses picnic_search to find gluten-free pasta
 2. Uses picnic_get_suggestions for dairy-free cheese alternatives
-3. Uses picnic_get_article to check ingredient details
+3. Uses picnic_get_product_details to check ingredient details
 4. Uses picnic_add_to_cart to add suitable products
 5. Provides cooking tips and substitution ratios
 ```
@@ -177,7 +176,7 @@ User: "I have €50 for groceries this week, help me maximize value"
 
 AI Actions:
 1. Uses picnic_search to find budget-friendly staples
-2. Uses picnic_get_categories to explore discount sections
+2. Uses picnic_get_suggestions to broaden product options
 3. Uses picnic_get_cart to track running total
 4. Uses picnic_remove_from_cart if budget exceeded
 5. Uses picnic_get_wallet_transactions to track spending patterns
@@ -191,10 +190,10 @@ AI Actions:
 User: "Create separate shopping lists for weekly groceries and party supplies"
 
 AI Actions:
-1. Uses picnic_get_lists to view existing lists
-2. Uses picnic_get_list to check current items
+1. Uses picnic_get_cart to review the current basket
+2. Uses picnic_search to find missing items
 3. Uses picnic_search to find party-specific items
-4. Organizes items by category using picnic_get_categories
+4. Uses picnic_get_product_details to validate sizes and quantities
 5. Uses picnic_add_to_cart when ready to order
 ```
 
@@ -210,7 +209,7 @@ AI Actions:
 2. Uses picnic_get_suggestions for wine pairings
 3. Uses picnic_get_delivery_slots to schedule Friday delivery
 4. Uses picnic_set_delivery_slot to book optimal time
-5. Uses picnic_get_article to check product availability and sizes
+5. Uses picnic_get_product_details to check product availability and sizes
 ```
 
 ### 🥗 **Health & Dietary Management**
@@ -222,7 +221,7 @@ User: "Find low-carb options for a diabetic-friendly weekly menu"
 
 AI Actions:
 1. Uses picnic_search with specific dietary keywords
-2. Uses picnic_get_article to check nutritional information
+2. Uses picnic_get_product_details to check nutritional information
 3. Uses picnic_get_suggestions for healthy alternatives
 4. Uses picnic_add_to_cart for approved items only
 5. Tracks nutritional goals across multiple meals
@@ -252,8 +251,8 @@ User: "Compare prices for organic vs conventional produce this week"
 
 AI Actions:
 1. Uses picnic_search for both organic and conventional items
-2. Uses picnic_get_article to compare prices and sizes
-3. Uses picnic_get_categories to explore different brands
+2. Uses picnic_get_product_details to compare prices and sizes
+3. Uses picnic_get_suggestions to explore different brands
 4. Uses picnic_get_suggestions for similar products
 5. Provides detailed cost analysis and recommendations
 ```
@@ -270,7 +269,7 @@ AI Actions:
 2. Uses picnic_get_delivery_scenario for driver communication
 3. Uses picnic_rate_delivery after completion
 4. Uses picnic_send_delivery_invoice_email for records
-5. Uses picnic_get_mgm_details to share referral benefits
+5. Uses picnic_get_delivery to review the final delivery summary
 ```
 
 ### 💳 **Financial Tracking**
@@ -346,7 +345,7 @@ PICNIC_PASSWORD=your-picnic-password
 
 # Country Configuration (optional, defaults to NL)
 # Set this to match your Picnic account's country
-# Supported values: NL (Netherlands), DE (Germany), FR (France)
+# Supported values: NL (Netherlands), DE (Germany)
 PICNIC_COUNTRY_CODE=NL
 
 # HTTP Transport settings (optional)
@@ -366,11 +365,8 @@ The `PICNIC_COUNTRY_CODE` setting determines which Picnic regional API to connec
 - **Supported values**:
   - `NL` - Netherlands (🇳🇱)
   - `DE` - Germany (🇩🇪)
-  - `FR` - France (🇫🇷)
-
 **When to set this:**
 - If your Picnic account is registered in Germany, you **must** set `PICNIC_COUNTRY_CODE=DE`
-- If your Picnic account is registered in France, you **must** set `PICNIC_COUNTRY_CODE=FR`
 - If your Picnic account is in the Netherlands, you can omit this setting (defaults to `NL`)
 
 **Example for German accounts:**
@@ -409,7 +405,7 @@ PICNIC_COUNTRY_CODE=DE
 
 **Important**:
 - Replace the placeholder credentials with your actual Picnic account details
-- Set `PICNIC_COUNTRY_CODE` to `"DE"` for Germany, `"FR"` for France, or `"NL"` for the Netherlands (default)
+- Set `PICNIC_COUNTRY_CODE` to `"DE"` for Germany, or `"NL"` for the Netherlands (default)
 
 **Setup Steps:**
 
@@ -442,7 +438,7 @@ Add to your Continue configuration:
 }
 ```
 
-**Note**: Set `PICNIC_COUNTRY_CODE` to `"DE"` for Germany or `"FR"` for France. Netherlands accounts can omit this field (defaults to `"NL"`).
+**Note**: Set `PICNIC_COUNTRY_CODE` to `"DE"` for Germany. Netherlands accounts can omit this field (defaults to `"NL"`).
 
 ## Authentication
 
@@ -487,9 +483,8 @@ The server provides comprehensive access to Picnic's functionality through 25+ s
 
 - **`picnic_search`** - Search for products by name or keywords
 - **`picnic_get_suggestions`** - Get product suggestions based on query
-- **`picnic_get_article`** - Get detailed information about a specific product
+- **`picnic_get_product_details`** - Get product details by selling unit ID
 - **`picnic_get_image`** - Get product images in various sizes (tiny to extra-large)
-- **`picnic_get_categories`** - Browse product categories with configurable depth
 
 ### Shopping Cart Management
 
@@ -511,17 +506,11 @@ The server provides comprehensive access to Picnic's functionality through 25+ s
 - **`picnic_send_delivery_invoice_email`** - Send/resend delivery invoice emails
 - **`picnic_get_order_status`** - Check status of specific orders
 
-### Lists & Organization
-
-- **`picnic_get_lists`** - Get shopping lists and sublists with configurable depth
-- **`picnic_get_list`** - Get specific list or sublist with all items
-
 ### Payment & Financial
 
 - **`picnic_get_payment_profile`** - View payment methods and billing information
 - **`picnic_get_wallet_transactions`** - Get wallet transaction history (paginated)
 - **`picnic_get_wallet_transaction_details`** - Get detailed transaction information
-- **`picnic_get_mgm_details`** - Get MGM (friends discount) program details
 
 ## Development
 
@@ -751,7 +740,7 @@ Gebruiker: "Ik wil lasagne maken maar heb glutenvrije en zuivelvrije alternatiev
 AI Acties:
 1. Gebruikt picnic_search om glutenvrije pasta te vinden
 2. Gebruikt picnic_get_suggestions voor zuivelvrije kaas alternatieven
-3. Gebruikt picnic_get_article om ingrediënt details te controleren
+3. Gebruikt picnic_get_product_details om ingrediëntdetails te controleren
 4. Gebruikt picnic_add_to_cart om geschikte producten toe te voegen
 5. Geeft kooktips en vervangingsverhoudingen
 ```
@@ -780,7 +769,7 @@ Gebruiker: "Ik heb €50 voor boodschappen deze week, help me de waarde te maxim
 
 AI Acties:
 1. Gebruikt picnic_search om budget-vriendelijke basisproducten te vinden
-2. Gebruikt picnic_get_categories om kortingssecties te verkennen
+2. Gebruikt picnic_get_suggestions om meer productopties te verkennen
 3. Gebruikt picnic_get_cart om lopend totaal bij te houden
 4. Gebruikt picnic_remove_from_cart als budget overschreden wordt
 5. Gebruikt picnic_get_wallet_transactions om uitgavenpatronen te volgen
@@ -794,10 +783,10 @@ AI Acties:
 Gebruiker: "Maak aparte boodschappenlijsten voor wekelijkse boodschappen en feestbenodigdheden"
 
 AI Acties:
-1. Gebruikt picnic_get_lists om bestaande lijsten te bekijken
-2. Gebruikt picnic_get_list om huidige items te controleren
+1. Gebruikt picnic_get_cart om het huidige mandje te bekijken
+2. Gebruikt picnic_search om ontbrekende items te vinden
 3. Gebruikt picnic_search om feest-specifieke items te vinden
-4. Organiseert items per categorie met picnic_get_categories
+4. Gebruikt picnic_get_product_details om formaten en hoeveelheden te controleren
 5. Gebruikt picnic_add_to_cart wanneer klaar om te bestellen
 ```
 
@@ -813,7 +802,7 @@ AI Acties:
 2. Gebruikt picnic_get_suggestions voor wijn combinaties
 3. Gebruikt picnic_get_delivery_slots om vrijdag bezorging in te plannen
 4. Gebruikt picnic_set_delivery_slot om optimale tijd te boeken
-5. Gebruikt picnic_get_article om product beschikbaarheid en maten te controleren
+5. Gebruikt picnic_get_product_details om productbeschikbaarheid en maten te controleren
 ```
 
 ### 🥗 **Gezondheid & Dieet Beheer**
@@ -825,7 +814,7 @@ Gebruiker: "Vind koolhydraatarme opties voor een diabetesvriendelijk weekmenu"
 
 AI Acties:
 1. Gebruikt picnic_search met specifieke dieet zoekwoorden
-2. Gebruikt picnic_get_article om voedingswaarde informatie te controleren
+2. Gebruikt picnic_get_product_details om voedingsinformatie te controleren
 3. Gebruikt picnic_get_suggestions voor gezonde alternatieven
 4. Gebruikt picnic_add_to_cart alleen voor goedgekeurde items
 5. Volgt voedingsdoelen over meerdere maaltijden
@@ -855,8 +844,8 @@ Gebruiker: "Vergelijk prijzen voor biologische vs conventionele groenten deze we
 
 AI Acties:
 1. Gebruikt picnic_search voor zowel biologische als conventionele items
-2. Gebruikt picnic_get_article om prijzen en maten te vergelijken
-3. Gebruikt picnic_get_categories om verschillende merken te verkennen
+2. Gebruikt picnic_get_product_details om prijzen en maten te vergelijken
+3. Gebruikt picnic_get_suggestions om verschillende merken te verkennen
 4. Gebruikt picnic_get_suggestions voor vergelijkbare producten
 5. Geeft gedetailleerde kostenanalyse en aanbevelingen
 ```
@@ -873,7 +862,7 @@ AI Acties:
 2. Gebruikt picnic_get_delivery_scenario voor chauffeur communicatie
 3. Gebruikt picnic_rate_delivery na voltooiing
 4. Gebruikt picnic_send_delivery_invoice_email voor administratie
-5. Gebruikt picnic_get_mgm_details om doorverwijsvoordelen te delen
+5. Gebruikt picnic_get_delivery om het bezorgoverzicht te controleren
 ```
 
 ### 💳 **Financiële Tracking**
@@ -1070,7 +1059,7 @@ Benutzer: "Ich möchte Lasagne machen, brauche aber glutenfreie und milchfreie A
 KI-Aktionen:
 1. Verwendet picnic_search um glutenfreie Pasta zu finden
 2. Verwendet picnic_get_suggestions für milchfreie Käse-Alternativen
-3. Verwendet picnic_get_article um Zutatdetails zu prüfen
+3. Verwendet picnic_get_product_details um Zutatdetails zu prüfen
 4. Verwendet picnic_add_to_cart um geeignete Produkte hinzuzufügen
 5. Gibt Kochtipps und Ersatzverhältnisse
 ```
@@ -1099,7 +1088,7 @@ Benutzer: "Ich habe €50 für Lebensmittel diese Woche, hilf mir den Wert zu ma
 
 KI-Aktionen:
 1. Verwendet picnic_search um budgetfreundliche Grundnahrungsmittel zu finden
-2. Verwendet picnic_get_categories um Rabattbereiche zu erkunden
+2. Verwendet picnic_get_suggestions um weitere Produktoptionen zu erkunden
 3. Verwendet picnic_get_cart um laufende Gesamtsumme zu verfolgen
 4. Verwendet picnic_remove_from_cart wenn Budget überschritten wird
 5. Verwendet picnic_get_wallet_transactions um Ausgabenmuster zu verfolgen
@@ -1113,10 +1102,10 @@ KI-Aktionen:
 Benutzer: "Erstelle separate Einkaufslisten für wöchentliche Lebensmittel und Partybedarf"
 
 KI-Aktionen:
-1. Verwendet picnic_get_lists um bestehende Listen anzuzeigen
-2. Verwendet picnic_get_list um aktuelle Artikel zu überprüfen
+1. Verwendet picnic_get_cart um den aktuellen Warenkorb zu prüfen
+2. Verwendet picnic_search um fehlende Artikel zu finden
 3. Verwendet picnic_search um party-spezifische Artikel zu finden
-4. Organisiert Artikel nach Kategorien mit picnic_get_categories
+4. Verwendet picnic_get_product_details um Größen und Mengen zu prüfen
 5. Verwendet picnic_add_to_cart wenn bereit zum Bestellen
 ```
 
@@ -1132,7 +1121,7 @@ KI-Aktionen:
 2. Verwendet picnic_get_suggestions für Weinpaarungen
 3. Verwendet picnic_get_delivery_slots um Freitag-Lieferung zu planen
 4. Verwendet picnic_set_delivery_slot um optimale Zeit zu buchen
-5. Verwendet picnic_get_article um Produktverfügbarkeit und Größen zu prüfen
+5. Verwendet picnic_get_product_details um Produktverfügbarkeit und Größen zu prüfen
 ```
 
 ### 🥗 **Gesundheits- & Diätmanagement**
@@ -1144,7 +1133,7 @@ Benutzer: "Finde kohlenhydratarme Optionen für ein diabetikerfreundliches Woche
 
 KI-Aktionen:
 1. Verwendet picnic_search mit spezifischen Diät-Suchbegriffen
-2. Verwendet picnic_get_article um Nährwertinformationen zu prüfen
+2. Verwendet picnic_get_product_details um Nährwertinformationen zu prüfen
 3. Verwendet picnic_get_suggestions für gesunde Alternativen
 4. Verwendet picnic_add_to_cart nur für genehmigte Artikel
 5. Verfolgt Ernährungsziele über mehrere Mahlzeiten
@@ -1174,8 +1163,8 @@ Benutzer: "Vergleiche Preise für Bio- vs. konventionelles Gemüse diese Woche"
 
 KI-Aktionen:
 1. Verwendet picnic_search für sowohl Bio- als auch konventionelle Artikel
-2. Verwendet picnic_get_article um Preise und Größen zu vergleichen
-3. Verwendet picnic_get_categories um verschiedene Marken zu erkunden
+2. Verwendet picnic_get_product_details um Preise und Größen zu vergleichen
+3. Verwendet picnic_get_suggestions um verschiedene Marken zu erkunden
 4. Verwendet picnic_get_suggestions für ähnliche Produkte
 5. Bietet detaillierte Kostenanalyse und Empfehlungen
 ```
@@ -1192,7 +1181,7 @@ KI-Aktionen:
 2. Verwendet picnic_get_delivery_scenario für Fahrerkommunikation
 3. Verwendet picnic_rate_delivery nach Abschluss
 4. Verwendet picnic_send_delivery_invoice_email für Aufzeichnungen
-5. Verwendet picnic_get_mgm_details um Empfehlungsvorteile zu teilen
+5. Verwendet picnic_get_delivery um die Lieferzusammenfassung zu prüfen
 ```
 
 ### 💳 **Finanzielle Verfolgung**

--- a/README.md
+++ b/README.md
@@ -483,12 +483,12 @@ The server provides comprehensive access to Picnic's functionality through 25+ s
 
 - **`picnic_search`** - Search for products by name or keywords
 - **`picnic_get_suggestions`** - Get product suggestions based on query
-- **`picnic_get_product_details`** - Get product details by selling unit ID
+- **`picnic_get_product_details`** - Get product details by selling unit ID, including bundle pricing when available
 - **`picnic_get_image`** - Get product images in various sizes (tiny to extra-large)
 
 ### Shopping Cart Management
 
-- **`picnic_get_cart`** - View current shopping cart contents and totals
+- **`picnic_get_cart`** - View current shopping cart contents, totals, and bundle discount savings when available
 - **`picnic_add_to_cart`** - Add products to cart with specified quantities
 - **`picnic_remove_from_cart`** - Remove products from cart with specified quantities
 - **`picnic_clear_cart`** - Clear all items from the shopping cart

--- a/package-lock.json
+++ b/package-lock.json
@@ -896,7 +896,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1648,7 +1647,6 @@
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1746,7 +1744,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2126,7 +2123,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3461,7 +3457,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3928,7 +3923,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4535,7 +4529,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4984,7 +4977,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5265,7 +5257,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7602,7 +7593,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8087,9 +8077,9 @@
       }
     },
     "node_modules/picnic-api": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.0.0.tgz",
-      "integrity": "sha512-cjP25V0Kx7WeYI4bZ14DLM2F+XdCeL8kydPkRvMpl8Ih3tiaTl7HzqPRP2eATDimm0UXcii55u3R1ovT9qSv6g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.2.0.tgz",
+      "integrity": "sha512-JCkI8kvjesfmfOzMNH153gekjQbvWaCOOCbJ1OdJYj0qz6ZzXwz56rAzC+7xH1v8M95NeNwGgmQovOIKe63Ong==",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.3.0"
@@ -8804,7 +8794,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9627,7 +9616,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9833,7 +9821,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9901,7 +9888,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10286,7 +10272,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10832,7 +10817,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11201,7 +11185,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
       "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "picnic-api": "^4.0.0",
+        "picnic-api": "^4.3.0",
         "zod": "^3.24.4",
         "zod-to-json-schema": "^3.25.1"
       },
@@ -8077,9 +8077,9 @@
       }
     },
     "node_modules/picnic-api": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.2.0.tgz",
-      "integrity": "sha512-JCkI8kvjesfmfOzMNH153gekjQbvWaCOOCbJ1OdJYj0qz6ZzXwz56rAzC+7xH1v8M95NeNwGgmQovOIKe63Ong==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.3.0.tgz",
+      "integrity": "sha512-0wFmXFJDq+nbRys2Qehls1B9Mz6vBEdCr7g4EBfA9DFnWi9iF8X3H6v7GCxpUAFktrCPFLMv0gIcTguaJENPMg==",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -896,6 +896,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1647,6 +1648,7 @@
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1744,6 +1746,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2123,6 +2126,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3457,6 +3461,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3923,6 +3928,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4529,6 +4535,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4977,6 +4984,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5257,6 +5265,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7593,6 +7602,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8794,6 +8804,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9616,6 +9627,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9821,6 +9833,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9888,6 +9901,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10272,6 +10286,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10817,6 +10832,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11185,6 +11201,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
       "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "picnic-api": "^4.0.0",
+    "picnic-api": "^4.3.0",
     "zod": "^3.24.4",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ const defaultSessionFile = path.join(os.homedir(), ".picnic-session.json")
 const configSchema = z.object({
   PICNIC_USERNAME: z.string(),
   PICNIC_PASSWORD: z.string(),
-  PICNIC_COUNTRY_CODE: z.enum(["NL", "DE", "FR"]).default("NL"),
+  PICNIC_COUNTRY_CODE: z.enum(["NL", "DE"]).default("NL"),
   ENABLE_HTTP_SERVER: z
     .string()
     .transform((val) => val === "true")

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -29,18 +29,26 @@ function filterCartData(cart: unknown) {
   const cartObj = cart as {
     type?: string
     id?: string
-    items?: Array<{
-      id?: string
-      display_price?: number
-      price?: number
       items?: Array<{
         id?: string
-        name?: string
-        unit_quantity?: string
+        display_price?: number
         price?: number
-        image_ids?: string[]
-        max_count?: number
-      }>
+        decorators?: Array<{
+          type?: string
+          text?: string
+        }>
+        items?: Array<{
+          id?: string
+          name?: string
+          unit_quantity?: string
+          price?: number
+          price_ranges?: Array<{
+            from_quantity?: number
+            price?: number
+          }>
+          image_ids?: string[]
+          max_count?: number
+        }>
     }>
     total_count?: number
     total_price?: number
@@ -51,11 +59,13 @@ function filterCartData(cart: unknown) {
   const filteredItems = cartObj.items?.map((orderLine) => ({
     order_line_id: orderLine.id,
     price: orderLine.display_price || orderLine.price,
+    ...(orderLine.decorators?.length && { decorators: orderLine.decorators }),
     articles: orderLine.items?.map((article) => ({
       product_id: article.id,
       name: article.name,
       unit: article.unit_quantity,
       price: article.price,
+      ...(article.price_ranges?.length && { bundle_prices: article.price_ranges }),
       ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
     })),
   }))
@@ -184,6 +194,7 @@ toolRegistry.register({
       brand: details.brand,
       price: details.displayPrice,
       unit: details.unitQuantity,
+      ...(details.priceRanges?.length && { bundle_prices: details.priceRanges }),
       ...(details.imageIds.length > 0 && { image_id: details.imageIds[0] }),
     }
   },

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -145,8 +145,8 @@ toolRegistry.register({
   },
 })
 
-// Note: picnic_get_article tool removed - endpoint deprecated (GitHub issue #23)
-// Use picnic_search instead for basic product information
+// Product details are exposed through picnic_get_product_details, which wraps
+// the v4 catalog product details endpoint and returns an LLM-friendly subset by default.
 
 // Get product details tool
 const productDetailsInputSchema = z.object({
@@ -604,31 +604,7 @@ toolRegistry.register({
     await ensureClientInitialized()
     const client = getPicnicClient()
 
-    // We bypass client.verify2FACode() because sendRequest doesn't capture response headers.
-    // The Picnic API may return an updated authKey in x-picnic-auth after 2FA verification.
-    const url = client.url
-    const authKey = client.authKey
-    const response = await fetch(`${url}/user/2fa/verify`, {
-      method: "POST",
-      headers: {
-        "User-Agent": "okhttp/3.12.2",
-        "Content-Type": "application/json; charset=UTF-8",
-        ...(authKey && { "x-picnic-auth": authKey }),
-        "x-picnic-agent": "30100;1.15.232-15154",
-        "x-picnic-did": "3C417201548B2E3B",
-      },
-      body: JSON.stringify({ otp: args.code }),
-    })
-
-    if (!response.ok) {
-      throw new Error(`2FA verification failed: ${response.status} ${response.statusText}`)
-    }
-
-    // Capture updated auth key if the API returns one
-    const newAuthKey = response.headers.get("x-picnic-auth")
-    if (newAuthKey) {
-      client.authKey = newAuthKey
-    }
+    await client.auth.verify2FACode(args.code)
 
     await saveSession()
     return {
@@ -637,4 +613,3 @@ toolRegistry.register({
     }
   },
 })
-

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { filterCartData, filterProductDetails } from "./picnic-transformers.js"
 import { toolRegistry } from "./registry.js"
 import { getPicnicClient, initializePicnicClient, saveSession } from "../utils/picnic-client.js"
 
@@ -16,68 +17,9 @@ import { getPicnicClient, initializePicnicClient, saveSession } from "../utils/p
 async function ensureClientInitialized() {
   try {
     getPicnicClient()
-  } catch (error) {
+  } catch {
     // Client not initialized, initialize it now
     await initializePicnicClient()
-  }
-}
-
-// Helper function to filter cart data for LLM consumption
-function filterCartData(cart: unknown) {
-  if (!cart || typeof cart !== "object") return cart
-
-  const cartObj = cart as {
-    type?: string
-    id?: string
-      items?: Array<{
-        id?: string
-        display_price?: number
-        price?: number
-        decorators?: Array<{
-          type?: string
-          text?: string
-        }>
-        items?: Array<{
-          id?: string
-          name?: string
-          unit_quantity?: string
-          price?: number
-          price_ranges?: Array<{
-            from_quantity?: number
-            price?: number
-          }>
-          image_ids?: string[]
-          max_count?: number
-        }>
-    }>
-    total_count?: number
-    total_price?: number
-    checkout_total_price?: number
-    total_savings?: number
-  }
-
-  const filteredItems = cartObj.items?.map((orderLine) => ({
-    order_line_id: orderLine.id,
-    price: orderLine.display_price || orderLine.price,
-    ...(orderLine.decorators?.length && { decorators: orderLine.decorators }),
-    articles: orderLine.items?.map((article) => ({
-      product_id: article.id,
-      name: article.name,
-      unit: article.unit_quantity,
-      price: article.price,
-      ...(article.price_ranges?.length && { bundle_prices: article.price_ranges }),
-      ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
-    })),
-  }))
-
-  return {
-    type: cartObj.type,
-    id: cartObj.id,
-    items: filteredItems,
-    total_count: cartObj.total_count,
-    total_price: cartObj.total_price,
-    checkout_total_price: cartObj.checkout_total_price,
-    total_savings: cartObj.total_savings,
   }
 }
 
@@ -188,15 +130,7 @@ toolRegistry.register({
       return details
     }
 
-    return {
-      id: details.id,
-      name: details.name,
-      brand: details.brand,
-      price: details.displayPrice,
-      unit: details.unitQuantity,
-      ...(details.priceRanges?.length && { bundle_prices: details.priceRanges }),
-      ...(details.imageIds.length > 0 && { image_id: details.imageIds[0] }),
-    }
+    return filterProductDetails(details)
   },
 })
 

--- a/src/tools/picnic-transformers.ts
+++ b/src/tools/picnic-transformers.ts
@@ -1,0 +1,168 @@
+type Scalar = string | number | boolean | null
+
+type PriceRangeLike = {
+  from_quantity?: number
+  price?: number
+}
+
+type CartArticleLike = {
+  id?: string
+  name?: string
+  unit_quantity?: string
+  price?: number
+  price_ranges?: PriceRangeLike[]
+  image_ids?: string[]
+}
+
+type CartOrderLineLike = {
+  id?: string
+  display_price?: number
+  price?: number
+  decorators?: unknown[]
+  items?: CartArticleLike[]
+}
+
+type CartLike = {
+  type?: string
+  id?: string
+  items?: CartOrderLineLike[]
+  total_count?: number
+  total_price?: number
+  checkout_total_price?: number
+  total_savings?: number
+}
+
+export type ProductDetailsLike = {
+  id?: string
+  name?: string
+  brand?: string
+  displayPrice?: number
+  unitQuantity?: string
+  priceRanges?: PriceRangeLike[] | null
+  imageIds?: string[] | null
+}
+
+export type FilteredProductDetails = {
+  id?: string
+  name?: string
+  brand?: string
+  price?: number
+  unit?: string
+  bundle_prices?: PriceRangeLike[]
+  image_id?: string
+}
+
+export type CompactDecorator = {
+  type: string
+  [key: string]: Scalar | undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function scalar(value: unknown): Scalar | undefined {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return value
+  }
+
+  return undefined
+}
+
+function compactDecorator(decorator: unknown): CompactDecorator | undefined {
+  if (!isRecord(decorator) || typeof decorator.type !== "string") {
+    return undefined
+  }
+
+  const type = decorator.type
+
+  switch (type) {
+    case "LABEL":
+    case "PRODUCT_SIZE":
+      return { type, text: scalar(decorator.text) }
+    case "PROMO":
+      return {
+        type,
+        text: scalar(decorator.text),
+        background_color: scalar(decorator.background_color),
+        text_color: scalar(decorator.text_color),
+      }
+    case "PRICE":
+      return { type, display_price: scalar(decorator.display_price) }
+    case "BASE_PRICE":
+      return { type, base_price_text: scalar(decorator.base_price_text) }
+    case "FRESH_LABEL":
+      return { type, period: scalar(decorator.period) }
+    case "QUANTITY":
+      return { type, quantity: scalar(decorator.quantity) }
+    case "UNIT_QUANTITY":
+      return { type, unit_quantity_text: scalar(decorator.unit_quantity_text) }
+    case "VALIDITY_LABEL":
+      return { type, valid_until: scalar(decorator.valid_until) }
+    default:
+      return undefined
+  }
+}
+
+function compactDecorators(decorators?: unknown[]) {
+  const filtered = decorators?.map(compactDecorator).filter((decorator) => decorator !== undefined)
+
+  return filtered?.length ? filtered : undefined
+}
+
+/**
+ * Filters Picnic cart data down to the fields that are useful in MCP responses.
+ */
+export function filterCartData(cart: unknown) {
+  if (!cart || typeof cart !== "object") return cart
+
+  const cartObj = cart as CartLike
+
+  const filteredItems = cartObj.items?.map((orderLine) => {
+    const decorators = compactDecorators(orderLine.decorators)
+
+    return {
+      order_line_id: orderLine.id,
+      price: orderLine.display_price ?? orderLine.price,
+      ...(decorators && { decorators }),
+      articles: orderLine.items?.map((article) => ({
+        product_id: article.id,
+        name: article.name,
+        unit: article.unit_quantity,
+        price: article.price,
+        ...(article.price_ranges?.length && { bundle_prices: article.price_ranges }),
+        ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
+      })),
+    }
+  })
+
+  return {
+    type: cartObj.type,
+    id: cartObj.id,
+    items: filteredItems,
+    total_count: cartObj.total_count,
+    total_price: cartObj.total_price,
+    checkout_total_price: cartObj.checkout_total_price,
+    total_savings: cartObj.total_savings,
+  }
+}
+
+/**
+ * Filters Picnic product details down to the default MCP response shape.
+ */
+export function filterProductDetails(details: ProductDetailsLike): FilteredProductDetails {
+  return {
+    id: details.id,
+    name: details.name,
+    brand: details.brand,
+    price: details.displayPrice,
+    unit: details.unitQuantity,
+    ...(details.priceRanges?.length && { bundle_prices: details.priceRanges }),
+    ...(details.imageIds?.length && { image_id: details.imageIds[0] }),
+  }
+}

--- a/src/utils/picnic-client.ts
+++ b/src/utils/picnic-client.ts
@@ -10,7 +10,7 @@ async function loadSession(): Promise<string | null> {
     const data = await fs.readFile(config.PICNIC_SESSION_FILE, "utf-8")
     const session = JSON.parse(data)
     return session.authKey || null
-  } catch (error) {
+  } catch {
     return null
   }
 }
@@ -53,7 +53,7 @@ export async function initializePicnicClient(
       picnicClientInstance = client
       console.error("Successfully reused saved session.")
       return
-    } catch (error) {
+    } catch {
       console.error("Saved session invalid, performing fresh login...")
       client.authKey = null // Clear invalid key before login
     }
@@ -63,7 +63,9 @@ export async function initializePicnicClient(
   picnicClientInstance = client
 
   if (loginResult?.second_factor_authentication_required) {
-    console.error("Picnic client logged in, but 2FA is required. Use the 2FA tools to complete authentication.")
+    console.error(
+      "Picnic client logged in, but 2FA is required. Use the 2FA tools to complete authentication.",
+    )
   } else {
     await saveSession()
     console.error("Picnic client initialized successfully.")

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -63,7 +63,7 @@ describe("Config Schema - PICNIC_COUNTRY_CODE (Issue #10 regression)", () => {
         configSchema.parse({
           PICNIC_USERNAME: "test-user",
           PICNIC_PASSWORD: "test-pass",
-          PICNIC_COUNTRY_CODE: "FR", // Invalid country code
+          PICNIC_COUNTRY_CODE: "FR",
         })
       }).toThrow()
     })

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -63,6 +63,7 @@ describe("Config Schema - PICNIC_COUNTRY_CODE (Issue #10 regression)", () => {
         configSchema.parse({
           PICNIC_USERNAME: "test-user",
           PICNIC_PASSWORD: "test-pass",
+          // Invalid country code: FR used to be valid before picnic-api 4.3.0.
           PICNIC_COUNTRY_CODE: "FR",
         })
       }).toThrow()

--- a/test/unit/tools/picnic-transformers.test.ts
+++ b/test/unit/tools/picnic-transformers.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest"
+import { filterCartData, filterProductDetails } from "../../../src/tools/picnic-transformers.js"
+
+describe("picnic transformers", () => {
+  describe("filterCartData", () => {
+    it("should expose bundle prices and total savings", () => {
+      const result = filterCartData({
+        type: "CART",
+        id: "cart-1",
+        total_count: 2,
+        total_price: 500,
+        checkout_total_price: 450,
+        total_savings: 50,
+        items: [
+          {
+            id: "line-1",
+            display_price: 450,
+            items: [
+              {
+                id: "s100",
+                name: "Apples",
+                unit_quantity: "1kg",
+                price: 250,
+                price_ranges: [{ from_quantity: 2, price: 225 }],
+                image_ids: ["image-1", "image-2"],
+              },
+            ],
+          },
+        ],
+      })
+
+      expect(result).toEqual({
+        type: "CART",
+        id: "cart-1",
+        items: [
+          {
+            order_line_id: "line-1",
+            price: 450,
+            articles: [
+              {
+                product_id: "s100",
+                name: "Apples",
+                unit: "1kg",
+                price: 250,
+                bundle_prices: [{ from_quantity: 2, price: 225 }],
+                image_id: "image-1",
+              },
+            ],
+          },
+        ],
+        total_count: 2,
+        total_price: 500,
+        checkout_total_price: 450,
+        total_savings: 50,
+      })
+    })
+
+    it("should keep compact decorators and remove large decorators", () => {
+      const result = filterCartData({
+        items: [
+          {
+            id: "line-1",
+            price: 100,
+            decorators: [
+              { type: "LABEL", text: "Organic" },
+              {
+                type: "PROMO",
+                text: "BundleBonus",
+                background_color: "#fff000",
+                text_color: "#111111",
+              },
+              { type: "PRICE", display_price: 100 },
+              { type: "BASE_PRICE", base_price_text: "1.00 / kg" },
+              { type: "FRESH_LABEL", period: "today" },
+              { type: "QUANTITY", quantity: 2 },
+              { type: "UNIT_QUANTITY", unit_quantity_text: "500g" },
+              { type: "PRODUCT_SIZE", text: "small" },
+              { type: "VALIDITY_LABEL", valid_until: "2026-05-20" },
+              { type: "BACKGROUND_IMAGE", image_ids: ["large-image"], height_percent: 100 },
+              { type: "BANNERS", banners: [{ image_id: "banner-image" }] },
+              { type: "MORE_BUTTON", images: ["button-image"], sellable_item_count: 12 },
+              { type: "UNAVAILABLE", replacements: [{ id: "replacement" }] },
+              { type: "ARTICLE_DELIVERY_FAILURES", failures: { s100: ["PRODUCT_ABSENT"] } },
+              { type: "PRODUCT_CHARACTERISTICS", characteristics: [{ type: "FROZEN" }] },
+              { type: "BUNDLES_BUTTON", deeplink: "picnic://bundle" },
+              { type: "ORDERED_QUANTITY", image_id: "quantity-image", quantity: "1" },
+              { type: "TITLE_STYLE", styles: [{ color: "#fff" }] },
+              { type: "IMMUTABLE" },
+            ],
+            items: [],
+          },
+        ],
+      })
+
+      expect(result).toMatchObject({
+        items: [
+          {
+            decorators: [
+              { type: "LABEL", text: "Organic" },
+              {
+                type: "PROMO",
+                text: "BundleBonus",
+                background_color: "#fff000",
+                text_color: "#111111",
+              },
+              { type: "PRICE", display_price: 100 },
+              { type: "BASE_PRICE", base_price_text: "1.00 / kg" },
+              { type: "FRESH_LABEL", period: "today" },
+              { type: "QUANTITY", quantity: 2 },
+              { type: "UNIT_QUANTITY", unit_quantity_text: "500g" },
+              { type: "PRODUCT_SIZE", text: "small" },
+              { type: "VALIDITY_LABEL", valid_until: "2026-05-20" },
+            ],
+          },
+        ],
+      })
+    })
+
+    it("should omit decorators when all decorators are filtered out", () => {
+      const result = filterCartData({
+        items: [
+          {
+            id: "line-1",
+            price: 100,
+            decorators: [{ type: "BACKGROUND_IMAGE", image_ids: ["large-image"] }],
+            items: [],
+          },
+        ],
+      })
+
+      expect(result).toEqual({
+        type: undefined,
+        id: undefined,
+        items: [
+          {
+            order_line_id: "line-1",
+            price: 100,
+            articles: [],
+          },
+        ],
+        total_count: undefined,
+        total_price: undefined,
+        checkout_total_price: undefined,
+        total_savings: undefined,
+      })
+    })
+  })
+
+  describe("filterProductDetails", () => {
+    it("should expose bundle prices and the first image ID", () => {
+      expect(
+        filterProductDetails({
+          id: "s100",
+          name: "Apples",
+          brand: "Picnic",
+          displayPrice: 250,
+          unitQuantity: "1kg",
+          priceRanges: [{ from_quantity: 2, price: 225 }],
+          imageIds: ["image-1", "image-2"],
+        }),
+      ).toEqual({
+        id: "s100",
+        name: "Apples",
+        brand: "Picnic",
+        price: 250,
+        unit: "1kg",
+        bundle_prices: [{ from_quantity: 2, price: 225 }],
+        image_id: "image-1",
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- switch 2FA verification to the upstream `picnic-api` helper now that v4 captures refreshed auth tokens correctly
- remove unsupported `FR` country handling and align config, tests, and docs with `NL`/`DE` only
- upgrade `picnic-api` to `4.3.0`
- expose bundle discount pricing and cart savings in MCP responses where available
- clean up public/internal documentation so the documented MCP tool surface matches the current implementation

## Changes

### 2FA flow
- replaced the custom `fetch()`-based implementation in `picnic_verify_2fa_code`
- now uses `client.auth.verify2FACode(...)`
- keeps session persistence after successful verification

### Country support
- removed `FR` from runtime config
- kept the Picnic client country typing aligned to `NL | DE`
- updated config tests accordingly

### Dependency update
- bumped `picnic-api` to `^4.3.0` in `package.json`
- refreshed `package-lock.json` to resolve `picnic-api@4.3.0`

### MCP tool updates
- `picnic_get_cart`
  - continues to return filtered cart data
  - now includes order-line `decorators` when present
  - continues to expose `total_savings`
  - now includes article-level `bundle_prices` when Picnic returns bundle pricing tiers

- `picnic_get_product_details`
  - default response still returns the concise subset
  - now also includes `bundle_prices` when bundle discount pricing is available on the product details page

### Documentation cleanup
- updated `README.md` to remove France references
- replaced stale tool references with the actual MCP tools currently exposed
- updated `PICNIC_TOOLS.md` to reflect the current tool surface
- added missing docs for:
  - `picnic_send_delivery_invoice_email`
  - `picnic_get_order_status`
- updated internal minispec docs to note that the 2FA fetch bypass is no longer needed
- documented bundle discount pricing in cart and product detail responses

## Why

`picnic-api` 4.0.1+ fixed the 2FA verification token refresh flow, so the local workaround is no longer necessary.

`picnic-api` 4.3.0 also adds support for bundle discount data in cart and product detail responses.

This repo had drifted in a few places:
- docs still referenced removed/stale tools
- config accepted `FR` while the client typing and tests did not
- some documentation no longer matched the current MCP implementation
- new bundle discount data from upstream was not surfaced clearly in MCP responses or docs

## Verification

- `npm install`
- `npm run typecheck`
- `npm test`

Result:
- typecheck passed
- tests passed (`195 passed`)

## Notes

This PR does not add Fusion-backed replacements for the old category/list APIs yet.
That follow-up still needs separate implementation work for:
- category discovery
- category product browsing
- weekly offers / promotion discovery