### PR TITLE
feat: add recipe browsing, meal planning tools, and MCP usage docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+export PICNIC_USERNAME="your.email@blabla.com"
+export PICNIC_PASSWORD="yourpassword"
+export PICNIC_COUNTRY_CODE="DE"
+export PICNIC_SESSION_FILE="/path/to/your/picnic_authkey.json"

--- a/API-USAGE.md
+++ b/API-USAGE.md
@@ -1,0 +1,44 @@
+# Listing All MCP Interfaces
+
+The following two methods can be used to list all MCP interfaces.
+
+---
+
+## 1. stdio
+
+Communicate with `mcp-picnic` (or `.start.sh`) via standard input/output:
+
+```bash
+printf '%s\n' \
+'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"cli","version":"1.0"}}}' \
+| mcp-picnic
+```
+
+> **Note:** `mcp-picnic` can be replaced with `.start.sh`.
+
+---
+
+## 2. HTTP + curl
+
+Communicate with a local service via HTTP request:
+
+```bash
+curl -i http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc":"2.0",
+    "id":1,
+    "method":"initialize",
+    "params":{
+      "protocolVersion":"2025-06-18",
+      "capabilities":{},
+      "clientInfo":{
+        "name":"curl",
+        "version":"1.0"
+      }
+    }
+  }'
+```
+
+> **Note:** The service must be running at `http://localhost:3000`.

--- a/API-USAGE.md
+++ b/API-USAGE.md
@@ -6,21 +6,22 @@ The following two methods can be used to list all MCP interfaces.
 
 ## 1. stdio
 
-Communicate with `mcp-picnic` (or `.start.sh`) via standard input/output:
+To run mcp-picnic as stdio server with `./bin/start.sh` via port 3000:
+
+First of all, you need to fill up the required information in ./.env with the same pattern in ./.env.example
+
+**Note:** In `picnic_authkey.json` you need to specify your picnic 2fa auth key like `{"authKey":"your picnic authKey"}`
 
 ```bash
-printf '%s\n' \
-'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"cli","version":"1.0"}}}' \
-| mcp-picnic
-```
+./start.sh --enable-http --http-port 3000
 
-> **Note:** `mcp-picnic` can be replaced with `.start.sh`.
+```
 
 ---
 
 ## 2. HTTP + curl
 
-Communicate with a local service via HTTP request:
+Communicate with the local running picnic mcp server on port 3000:
 
 ```bash
 curl -i http://localhost:3000/mcp \
@@ -41,4 +42,3 @@ curl -i http://localhost:3000/mcp \
   }'
 ```
 
-> **Note:** The service must be running at `http://localhost:3000`.

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -f "$(dirname "$0")/../.env" ] && source "$(dirname "$0")/../.env"
+exec node "$(dirname "$0")/mcp-server.js" "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -896,7 +896,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1648,7 +1647,6 @@
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1746,7 +1744,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2126,7 +2123,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3461,7 +3457,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3928,7 +3923,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4535,7 +4529,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4984,7 +4977,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5265,7 +5257,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7602,7 +7593,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8804,7 +8794,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9627,7 +9616,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9833,7 +9821,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9901,7 +9888,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10286,7 +10272,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10832,7 +10817,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11201,7 +11185,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
       "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1088,17 +1088,27 @@ Returns top_k combinations sorted by score descending, ties broken by lowest tot
 
 toolRegistry.register({
   name: "picnic_add_recipe_to_cart",
-  description: "Add a product to the cart in the context of a recipe (for analytics and recipe stepper UI).",
+  description: "Add a product to the cart in the context of a recipe (for analytics and recipe stepper UI). Uses SELLING_GROUP context so Picnic associates the item with the recipe.",
   inputSchema: z.object({
     productId: z.string().describe("The product selling unit ID"),
     recipeId: z.string().describe("The recipe ID this product belongs to"),
-    sectionId: z.string().optional().describe("Optional section ID within the recipe"),
     count: z.number().min(1).default(1).describe("Number of units to add"),
   }),
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    return client.recipe.addProductToRecipe(args.productId, args.recipeId, args.sectionId, args.count)
+    // The picnic-api library incorrectly uses type "RECIPE" which is rejected by the API.
+    // The correct type is "SELLING_GROUP" with selling_group_creator_type "PIM" for editorial recipes.
+    // PicnicClient extends HttpClient directly, so sendRequest is on the client itself.
+    return (client as unknown as { sendRequest: (method: string, path: string, body: unknown) => Promise<unknown> }).sendRequest("POST", "/cart/add_product", {
+      product_id: args.productId,
+      count: args.count,
+      selling_unit_contexts: [{
+        type: "SELLING_GROUP",
+        selling_group_id: args.recipeId,
+        selling_group_creator_type: "PIM",
+      }],
+    })
   },
 })
 

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -629,7 +629,8 @@ function extractRecipeList(pageData: unknown): Array<{ recipe_id: string; name: 
           const markdowns: string[] = []
           getMarkdowns(o.pml, markdowns)
           const texts = markdowns.map(t => t.replace(/#\([^)]+\)/g, "").trim()).filter(Boolean)
-          const name = texts[0] ?? ""
+          const UI_STRINGS = new Set(["Hinzufügen", "Nicht alles vorrätig"])
+          const name = markdowns.find(t => !t.includes("#(") && !UI_STRINGS.has(t.trim()) && t.trim())?.trim() ?? ""
           const timeText = texts.find(t => /Minuten|Stunden|Min|Std/.test(t)) ?? ""
           const timeMatch = timeText.match(/(\d+)/)
           const mult = /Stunden|Std/.test(timeText) ? 60 : 1
@@ -692,18 +693,396 @@ toolRegistry.register({
   },
 })
 
+type SellingUnit = { ingredient_id: string; selling_unit_id: string; quantity: number; checked: boolean }
+type RecipeContext = { recipe_id: string; recipe_name: string; portions: number; selling_units: SellingUnit[] }
+
+function extractRecipeContext(pageData: unknown): RecipeContext | null {
+  function walk(obj: unknown, depth: number): RecipeContext | null {
+    if (depth > 20 || !obj || typeof obj !== "object") return null
+    if (Array.isArray(obj)) {
+      for (const v of obj) { const r = walk(v, depth + 1); if (r) return r }
+      return null
+    }
+    const o = obj as Record<string, unknown>
+    const ctxs = (o.analytics as { contexts?: Array<{ data?: unknown }> } | undefined)?.contexts ?? []
+    for (const c of ctxs) {
+      const d = c.data as Record<string, unknown> | undefined
+      if (d?.selling_units && d?.portions && d?.recipe_name && d?.recipe_id) return d as unknown as RecipeContext
+    }
+    for (const v of Object.values(o)) { const r = walk(v, depth + 1); if (r) return r }
+    return null
+  }
+  return walk(pageData, 0)
+}
+
+type IngredientTile = { ingredient_id: string; name: string; package_info: string; price_cents: number | null }
+
+function extractIngredientTiles(pageData: unknown): IngredientTile[] {
+  const results: IngredientTile[] = []
+
+  function getMarkdowns(obj: unknown, acc: string[]): void {
+    if (!obj || typeof obj !== "object") return
+    if (Array.isArray(obj)) { obj.forEach(v => getMarkdowns(v, acc)); return }
+    const o = obj as Record<string, unknown>
+    if (typeof o.markdown === "string") acc.push(o.markdown)
+    for (const v of Object.values(o)) getMarkdowns(v, acc)
+  }
+
+  function walk(obj: unknown, depth: number): void {
+    if (depth > 60 || !obj || typeof obj !== "object") return
+    if (Array.isArray(obj)) { obj.forEach(v => walk(v, depth + 1)); return }
+    const o = obj as Record<string, unknown>
+    if (o.type === "PML" && o.analytics && o.pml) {
+      const ctxs = (o.analytics as { contexts?: Array<{ data?: Record<string, unknown>; schema?: string }> }).contexts ?? []
+      const productCtx = ctxs.find(c => c.data?.product_id && c.schema?.includes("/product/"))
+      if (productCtx) {
+        const ingredient_id = productCtx.data!.product_id as string
+        const markdowns: string[] = []
+        getMarkdowns(o.pml, markdowns)
+        const clean = markdowns
+          .map(t => t.replace(/#\([^)]+\)/g, "").replace(/\xa0/g, " ").trim())
+          .filter(Boolean)
+        // Name: first string that isn't a price, arrow, percentage, or discount badge like "-20%"
+        const name = clean.find(t => !/^[><%]/.test(t) && !/^-?\d+%/.test(t) && !/^\d+[.,]\d+$/.test(t) && !/€/.test(t) && !/jetzt/i.test(t)) ?? ""
+        // Package info: string with g/ml/kg/Stk/· or parenthetical
+        const package_info = clean.find(t => /g|ml|kg|Stk|·|\(/.test(t) && t !== name) ?? ""
+        // Price: extract cents from "jetzt 4.49€" or "4.49"
+        const priceStr = clean.find(t => /€|\d+[.,]\d{2}/.test(t)) ?? ""
+        const priceMatch = priceStr.match(/(\d+)[.,](\d{2})/)
+        const price_cents = priceMatch ? parseInt(priceMatch[1]) * 100 + parseInt(priceMatch[2]) : null
+        results.push({ ingredient_id, name, package_info, price_cents })
+        return
+      }
+    }
+    for (const v of Object.values(o)) walk(v, depth + 1)
+  }
+
+  walk(pageData, 0)
+  return results
+}
+
 const recipeDetailsInputSchema = z.object({
   recipeId: z.string().describe("The recipe ID (24-char hex string from picnic_get_cookbook or picnic_get_recipes_by_category)"),
 })
 
 toolRegistry.register({
-  name: "picnic_get_recipe_details",
-  description: "Get full details of a single recipe including ingredients (with product IDs for adding to cart), cooking steps, cooking time, and servings.",
+  name: "picnic_get_recipe_ingredients",
+  description: `Get structured ingredient list for a recipe. Returns each ingredient with:
+- name: product name
+- selling_unit_id: product ID for adding to cart
+- quantity: number of packages to buy (for the default portion count)
+- portions: default serving size this quantity is based on
+- is_condiment: true for staples the user likely already has (salt, oil, spices etc) — skip these when adding to cart
+- package_info: package size/description
+- price_cents: price in cents
+
+Use this to compare ingredients across recipes for meal planning and to build shopping lists.`,
   inputSchema: recipeDetailsInputSchema,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    return client.recipe.getRecipeDetailsPage(args.recipeId)
+    const page = await client.app.getPage(`selling-group-details-page?selling_group_id=${args.recipeId}`)
+    const ctx = extractRecipeContext(page)
+    if (!ctx) throw new Error("Could not find recipe data in response")
+    const tiles = extractIngredientTiles(page)
+    const tilesByIngredientId = new Map(tiles.map(t => [t.ingredient_id, t]))
+    return {
+      recipe_id: ctx.recipe_id,
+      recipe_name: ctx.recipe_name,
+      portions: ctx.portions,
+      ingredients: ctx.selling_units.map(u => {
+        const tile = tilesByIngredientId.get(u.ingredient_id)
+        return {
+          name: tile?.name ?? "",
+          selling_unit_id: u.selling_unit_id,
+          quantity: u.quantity,
+          is_condiment: !u.checked,
+          package_info: tile?.package_info ?? "",
+          price_cents: tile?.price_cents ?? null,
+        }
+      }),
+    }
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_get_multiple_recipe_ingredients",
+  description: `Fetch structured ingredient lists for multiple recipes in parallel. Accepts up to 20 recipe IDs and returns all results at once.
+
+Use this for meal planning: fetch ingredients for a set of candidate recipes, then compare across recipes to find combinations that share ingredients (minimizing leftover partial packages). Each result has the same shape as picnic_get_recipe_ingredients.
+
+Note: ingredients with quantity values much larger than expected (e.g. 40 for spring onions) are measured in grams/pieces from a single package — treat quantity=1 as "buy one pack" for those.`,
+  inputSchema: z.object({
+    recipeIds: z.array(z.string()).min(1).max(20).describe("List of recipe IDs (up to 20)"),
+  }),
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+
+    const results = await Promise.allSettled(
+      args.recipeIds.map(async (recipeId) => {
+        const page = await client.app.getPage(`selling-group-details-page?selling_group_id=${recipeId}`)
+        const ctx = extractRecipeContext(page)
+        if (!ctx) throw new Error(`Could not find recipe data for ${recipeId}`)
+        const tiles = extractIngredientTiles(page)
+        const tilesByIngredientId = new Map(tiles.map(t => [t.ingredient_id, t]))
+        return {
+          recipe_id: ctx.recipe_id,
+          recipe_name: ctx.recipe_name,
+          portions: ctx.portions,
+          ingredients: ctx.selling_units.map(u => {
+            const tile = tilesByIngredientId.get(u.ingredient_id)
+            return {
+              name: tile?.name ?? "",
+              selling_unit_id: u.selling_unit_id,
+              quantity: u.quantity,
+              is_condiment: !u.checked,
+              package_info: tile?.package_info ?? "",
+              price_cents: tile?.price_cents ?? null,
+            }
+          }),
+        }
+      })
+    )
+
+    return results.map((r, i) =>
+      r.status === "fulfilled"
+        ? r.value
+        : { recipe_id: args.recipeIds[i], error: (r.reason as Error).message }
+    )
+  },
+})
+
+// Shared ingredient input schema (matches output of picnic_get_multiple_recipe_ingredients)
+const recipeIngredientInput = z.object({
+  recipe_id: z.string(),
+  recipe_name: z.string(),
+  portions: z.number(),
+  ingredients: z.array(
+    z.object({
+      name: z.string(),
+      selling_unit_id: z.string(),
+      quantity: z.number(),
+      is_condiment: z.boolean(),
+      package_info: z.string(),
+      price_cents: z.number().nullable(),
+    })
+  ),
+})
+
+toolRegistry.register({
+  name: "picnic_build_shopping_list",
+  description: `Given a list of recipes (output of picnic_get_multiple_recipe_ingredients), consolidates all non-condiment ingredients into a single shopping list.
+
+Shared ingredients (same product needed by multiple recipes) are flagged with used_in_recipes and potentially_shareable=true when package_info suggests partial usage (e.g. "0.5 Stk. benötigt"). For those items, one package may cover both recipes — quantity is a conservative sum across all recipes, so the actual amount to buy may be less.
+
+Returns:
+- shopping_list: deduplicated items sorted by price descending; quantity is the sum across all recipes (conservative — for potentially_shareable items the real quantity may be lower)
+- shared_items: subset of shopping_list used in 2+ recipes
+- total_price_cents: sum of price_cents × quantity for all items (null prices counted as 0)
+- recipes_summary: names and portions of included recipes`,
+  inputSchema: z.object({
+    recipes: z.array(recipeIngredientInput).min(1).max(20),
+  }),
+  handler: async (args) => {
+    type ShoppingItem = {
+      selling_unit_id: string
+      name: string
+      package_info: string
+      price_cents: number | null
+      quantity: number
+      used_in_recipes: string[]
+      potentially_shareable: boolean
+    }
+
+    const itemMap = new Map<string, ShoppingItem>()
+
+    for (const recipe of args.recipes) {
+      const seenInRecipe = new Set<string>()
+      for (const ing of recipe.ingredients) {
+        if (ing.is_condiment) continue
+        if (seenInRecipe.has(ing.selling_unit_id)) continue
+        seenInRecipe.add(ing.selling_unit_id)
+        const isPartial = /benötigt|\d+[\.,]\d+\s*(Stk|Stück|St\.)/i.test(ing.package_info)
+        const existing = itemMap.get(ing.selling_unit_id)
+        if (existing) {
+          existing.used_in_recipes.push(recipe.recipe_name)
+          existing.quantity += ing.quantity
+          if (isPartial) existing.potentially_shareable = true
+        } else {
+          itemMap.set(ing.selling_unit_id, {
+            selling_unit_id: ing.selling_unit_id,
+            name: ing.name,
+            package_info: ing.package_info,
+            price_cents: ing.price_cents,
+            quantity: ing.quantity,
+            used_in_recipes: [recipe.recipe_name],
+            potentially_shareable: isPartial,
+          })
+        }
+      }
+    }
+
+    const shopping_list = Array.from(itemMap.values()).sort(
+      (a, b) => (b.price_cents ?? 0) - (a.price_cents ?? 0)
+    )
+    const shared_items = shopping_list.filter(i => i.used_in_recipes.length > 1)
+    const total_price_cents = shopping_list.reduce((sum, i) => sum + (i.price_cents ?? 0) * i.quantity, 0)
+
+    return {
+      shopping_list,
+      shared_items,
+      total_price_cents,
+      recipes_summary: args.recipes.map(r => ({ recipe_id: r.recipe_id, recipe_name: r.recipe_name, portions: r.portions })),
+    }
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_find_meal_combinations",
+  description: `Given a pool of recipes with their ingredients, finds the best combinations of N recipes that maximizes shared ingredients (minimizing food waste from leftover partial packages).
+
+Algorithm (chosen automatically):
+- Exhaustive search when the combination space is manageable (≤ 30,000 combinations). The candidate pool is dynamically capped so C(candidates, count) stays within this limit — guarantees the optimal result.
+- Greedy search when exhaustive would be too expensive: tries starting from every recipe in the pool, each time greedily picking the next recipe with the highest overlap score. Fast and finds good (not necessarily optimal) results.
+
+Scoring: each shared non-condiment ingredient (same selling_unit_id in 2+ recipes) = +1 point; +2 bonus if package_info indicates partial usage (e.g. "0.5 Stk. benötigt") since those are the real waste-reduction wins.
+
+Returns top_k combinations sorted by score descending, ties broken by lowest total cost.`,
+  inputSchema: z.object({
+    recipes: z.array(recipeIngredientInput).min(2).max(50),
+    count: z.number().int().min(2).describe("Number of recipes per combination (days to plan)"),
+    top_k: z.number().int().min(1).max(20).default(5).describe("How many top combinations to return"),
+    maxCookingMinutes: z.number().optional().describe("Exclude recipes above this cooking time (requires cookingTimeByRecipe)"),
+    maxTotalBudgetCents: z.number().optional().describe("Exclude combinations whose total cost exceeds this value"),
+    cookingTimeByRecipe: z
+      .array(z.object({ recipe_id: z.string(), cooking_time_minutes: z.number().nullable() }))
+      .optional()
+      .describe("Cooking times per recipe — from picnic_get_cookbook or picnic_get_recipes_by_category output"),
+  }),
+  handler: async (args) => {
+    type RecipeData = (typeof args.recipes)[number]
+
+    // Filter by cooking time
+    let pool: RecipeData[] = args.recipes
+    if (args.maxCookingMinutes != null) {
+      if (!args.cookingTimeByRecipe) {
+        return { error: "maxCookingMinutes requires cookingTimeByRecipe to be provided" }
+      }
+      const timeMap = new Map(args.cookingTimeByRecipe.map(r => [r.recipe_id, r.cooking_time_minutes]))
+      pool = pool.filter(r => {
+        const t = timeMap.get(r.recipe_id)
+        return t == null || t <= args.maxCookingMinutes!
+      })
+    }
+
+    if (pool.length < args.count) {
+      return { error: `Not enough recipes after filtering (${pool.length} available, ${args.count} requested)` }
+    }
+
+    function nChooseK(n: number, k: number): number {
+      if (k > n) return 0
+      if (k === 0 || k === n) return 1
+      let result = 1
+      for (let i = 0; i < k; i++) result = (result * (n - i)) / (i + 1)
+      return Math.round(result)
+    }
+
+    type CombinationResult = {
+      recipes: Array<{ recipe_id: string; recipe_name: string }>
+      shared_items: Array<{ selling_unit_id: string; name: string; package_info: string; used_in_recipes: string[] }>
+      total_price_cents: number
+      score: number
+      algorithm: "exhaustive" | "greedy"
+    }
+
+    function scoreCombination(combo: RecipeData[]) {
+      const itemMap = new Map<string, { name: string; package_info: string; price_cents: number | null; recipes: string[] }>()
+      for (const recipe of combo) {
+        const seenInRecipe = new Set<string>()
+        for (const ing of recipe.ingredients) {
+          if (ing.is_condiment) continue
+          if (seenInRecipe.has(ing.selling_unit_id)) continue
+          seenInRecipe.add(ing.selling_unit_id)
+          const existing = itemMap.get(ing.selling_unit_id)
+          if (existing) {
+            existing.recipes.push(recipe.recipe_name)
+          } else {
+            itemMap.set(ing.selling_unit_id, { name: ing.name, package_info: ing.package_info, price_cents: ing.price_cents, recipes: [recipe.recipe_name] })
+          }
+        }
+      }
+      const shared_items = Array.from(itemMap.entries())
+        .filter(([, v]) => v.recipes.length > 1)
+        .map(([id, v]) => ({ selling_unit_id: id, name: v.name, package_info: v.package_info, used_in_recipes: v.recipes }))
+      const score = shared_items.reduce((s, item) => {
+        const partial = /benötigt|\d+[\.,]\d+\s*(Stk|Stück|St\.)/i.test(item.package_info)
+        return s + 1 + (partial ? 2 : 0)
+      }, 0)
+      const total_price_cents = Array.from(itemMap.values()).reduce((sum, v) => sum + (v.price_cents ?? 0), 0)
+      return { shared_items, total_price_cents, score }
+    }
+
+    const EXHAUSTIVE_LIMIT = 30_000
+    const n = args.count
+    const topK = args.top_k
+    const seen = new Map<string, CombinationResult>()
+
+    function addResult(combo: RecipeData[], algorithm: "exhaustive" | "greedy") {
+      const key = combo.map(r => r.recipe_id).sort().join(",")
+      if (seen.has(key)) return
+      const { shared_items, total_price_cents, score } = scoreCombination(combo)
+      if (args.maxTotalBudgetCents == null || total_price_cents <= args.maxTotalBudgetCents) {
+        seen.set(key, {
+          recipes: combo.map(r => ({ recipe_id: r.recipe_id, recipe_name: r.recipe_name })),
+          shared_items,
+          total_price_cents,
+          score,
+          algorithm,
+        })
+      }
+    }
+
+    // Find the largest candidate pool that keeps C(pool, n) within the exhaustive limit
+    let candidateCap = Math.min(pool.length, 50)
+    while (candidateCap > n && nChooseK(candidateCap, n) > EXHAUSTIVE_LIMIT) {
+      candidateCap--
+    }
+
+    const useExhaustive = nChooseK(candidateCap, n) <= EXHAUSTIVE_LIMIT
+    const candidates = pool.slice(0, useExhaustive ? candidateCap : 50)
+
+    if (useExhaustive) {
+      function combine(start: number, current: RecipeData[]) {
+        if (current.length === n) { addResult(current, "exhaustive"); return }
+        for (let i = start; i <= candidates.length - (n - current.length); i++) {
+          combine(i + 1, [...current, candidates[i]])
+        }
+      }
+      combine(0, [])
+    } else {
+      // Greedy: start from each candidate, greedily pick highest-overlap addition each step
+      for (const start of candidates) {
+        const selected: RecipeData[] = [start]
+        const selectedIds = new Set([start.recipe_id])
+        while (selected.length < n) {
+          let bestScore = -1
+          let bestRecipe: RecipeData | null = null
+          for (const candidate of candidates) {
+            if (selectedIds.has(candidate.recipe_id)) continue
+            const { score } = scoreCombination([...selected, candidate])
+            if (score > bestScore) { bestScore = score; bestRecipe = candidate }
+          }
+          if (!bestRecipe) break
+          selected.push(bestRecipe)
+          selectedIds.add(bestRecipe.recipe_id)
+        }
+        if (selected.length === n) addResult(selected, "greedy")
+      }
+    }
+
+    const results = Array.from(seen.values()).sort((a, b) => b.score - a.score || a.total_price_cents - b.total_price_cents)
+    return results.slice(0, topK)
   },
 })
 

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -596,6 +596,135 @@ const verify2FAInputSchema = z.object({
   code: z.string().describe("The 2FA code to verify"),
 })
 
+// ─── Recipe tools ────────────────────────────────────────────────────────────
+
+/**
+ * Extracts a compact recipe list from a Fusion Page response.
+ * Each PML tile contains the recipe_id in its analytics context and the
+ * recipe name + cooking time in its markdown fields.
+ */
+function extractRecipeList(pageData: unknown): Array<{ recipe_id: string; name: string; cooking_time_minutes: number | null }> {
+  const results: Array<{ recipe_id: string; name: string; cooking_time_minutes: number | null }> = []
+  const seen = new Set<string>()
+
+  function getMarkdowns(obj: unknown, acc: string[]): void {
+    if (!obj || typeof obj !== "object") return
+    if (Array.isArray(obj)) { obj.forEach(v => getMarkdowns(v, acc)); return }
+    const o = obj as Record<string, unknown>
+    if (typeof o.markdown === "string") acc.push(o.markdown)
+    for (const v of Object.values(o)) getMarkdowns(v, acc)
+  }
+
+  function walk(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return
+    if (Array.isArray(obj)) { obj.forEach(walk); return }
+    const o = obj as Record<string, unknown>
+    if (o.type === "PML" && o.pml && o.analytics) {
+      const ctx = (o.analytics as { contexts?: Array<{ data?: { recipe_id?: string } }> }).contexts ?? []
+      const recipeCtx = ctx.find(c => c.data?.recipe_id)
+      if (recipeCtx?.data?.recipe_id) {
+        const recipeId = recipeCtx.data.recipe_id
+        if (!seen.has(recipeId)) {
+          seen.add(recipeId)
+          const markdowns: string[] = []
+          getMarkdowns(o.pml, markdowns)
+          const texts = markdowns.map(t => t.replace(/#\([^)]+\)/g, "").trim()).filter(Boolean)
+          const name = texts[0] ?? ""
+          const timeText = texts.find(t => /Minuten|Stunden|Min|Std/.test(t)) ?? ""
+          const timeMatch = timeText.match(/(\d+)/)
+          const mult = /Stunden|Std/.test(timeText) ? 60 : 1
+          const cooking_time_minutes = timeMatch ? parseInt(timeMatch[1]) * mult : null
+          results.push({ recipe_id: recipeId, name, cooking_time_minutes })
+        }
+      }
+    }
+    for (const v of Object.values(o)) walk(v)
+  }
+
+  walk(pageData)
+  return results
+}
+
+toolRegistry.register({
+  name: "picnic_get_cookbook",
+  description: "Get recipes shown on the Picnic cookbook homepage (mix of this week's picks, new recipes, collaborations, and saved recipes). Returns a compact list with recipe_id, name, and cooking_time_minutes.",
+  inputSchema: z.object({}),
+  handler: async () => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const page = await client.app.getPage("cookbook-page-content?segment=ALL_RECIPES")
+    return extractRecipeList(page)
+  },
+})
+
+const recipesByCategoryInputSchema = z.object({
+  categoryPageId: z.string().describe(
+    "Category page ID. Available values: " +
+    "recipe-cattree-25min (Blitzrezepte ~1000), recipe-cattree-onepot, " +
+    "recipe-cattree-pasta (~248), recipe-cattree-stuffedpasta, recipe-cattree-lasagne, " +
+    "recipe-cattree-gnocchi, recipe-cattree-noodles, recipe-cattree-schupfnudeln, " +
+    "recipe-cattree-maultaschen, recipe-cattree-spaetzle, recipe-cattree-asia-reis, " +
+    "recipe-cattree-risotto, recipe-cattree-couscous, recipe-cattree-bulgur, " +
+    "recipe-cattree-knoedel, recipe-cattree-kartoffel, recipe-cattree-suppen (~78), " +
+    "recipe-cattree-eintopf, recipe-cattree-curry2, recipe-cattree-l2-salad, " +
+    "recipe-cattree-bowls, recipe-cattree-wraps, recipe-cattree-pita2, " +
+    "recipe-cattree-l2-burger, recipe-cattree-quiche, recipe-cattree-traybake, " +
+    "recipe-cattree-auflaufe, recipe-cattree-l2-pizza, " +
+    "recipe-cattree-vegetarisch (~930), recipe-cattree-vegan (~132), " +
+    "recipe-cattree-highinveg, recipe-cattree-brunch, recipe-cattree-aperitif, " +
+    "recipe-cattree-dessert, recipe-cattree-abendbrot, recipe-cattree-bbq, " +
+    "recipe-cattree-l2-party, recipe-cattree-basic, recipe-cattree-baking, " +
+    "recipe-cattree-snacks, recipe-cattree-getraenke, recipe-cattree-airfryer, " +
+    "recipe-cattree-budget (~628), recipe-cattree-jamieoliver, " +
+    "recipe-cattree-season (~183), recipe-cattree-l2-kids"
+  ),
+})
+
+toolRegistry.register({
+  name: "picnic_get_recipes_by_category",
+  description: "Get all recipes for a Picnic recipe category. Returns a compact list with recipe_id, name, and cooking_time_minutes. Categories contain hundreds of recipes each.",
+  inputSchema: recipesByCategoryInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const page = await client.app.getPage(args.categoryPageId)
+    return extractRecipeList(page)
+  },
+})
+
+const recipeDetailsInputSchema = z.object({
+  recipeId: z.string().describe("The recipe ID (24-char hex string from picnic_get_cookbook or picnic_get_recipes_by_category)"),
+})
+
+toolRegistry.register({
+  name: "picnic_get_recipe_details",
+  description: "Get full details of a single recipe including ingredients (with product IDs for adding to cart), cooking steps, cooking time, and servings.",
+  inputSchema: recipeDetailsInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    return client.recipe.getRecipeDetailsPage(args.recipeId)
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_add_recipe_to_cart",
+  description: "Add a product to the cart in the context of a recipe (for analytics and recipe stepper UI).",
+  inputSchema: z.object({
+    productId: z.string().describe("The product selling unit ID"),
+    recipeId: z.string().describe("The recipe ID this product belongs to"),
+    sectionId: z.string().optional().describe("Optional section ID within the recipe"),
+    count: z.number().min(1).default(1).describe("Number of units to add"),
+  }),
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    return client.recipe.addProductToRecipe(args.productId, args.recipeId, args.sectionId, args.count)
+  },
+})
+
+// ─── 2FA ─────────────────────────────────────────────────────────────────────
+
 toolRegistry.register({
   name: "picnic_verify_2fa_code",
   description: "Verify a 2FA code",


### PR DESCRIPTION
## Summary

- **Recipe & meal planning tools** — adds 7 new MCP tools to `picnic-tools.ts`:
  - `picnic_get_cookbook` / `picnic_get_recipes_by_category` — browse available recipes
  - `picnic_get_recipe_ingredients` / `picnic_get_multiple_recipe_ingredients` — fetch ingredient lists
  - `picnic_build_shopping_list` — consolidate ingredients across multiple recipes
  - `picnic_find_meal_combinations` — find recipe combinations that share ingredients to reduce waste
  - `picnic_add_recipe_to_cart` — add all recipe ingredients to the cart in one step

- **MCP usage documentation** — adds `API-USAGE.md` with examples for connecting via stdio and HTTP/curl, plus `.env.example` and `bin/start.sh` for easier setup

- **Fix** — uses `SELLING_GROUP` context in `picnic_add_recipe_to_cart`
