### PR TITLE
feat: configurable per-install deviceId and agent (#39)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "picnic-api": "^4.0.0",
+        "picnic-api": "^4.4.0",
         "zod": "^3.24.4",
         "zod-to-json-schema": "^3.25.1"
       },
@@ -896,7 +896,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1648,7 +1647,6 @@
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1746,7 +1744,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2126,7 +2123,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3461,7 +3457,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3928,7 +3923,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4535,7 +4529,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4984,7 +4977,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5265,7 +5257,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7602,7 +7593,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8087,9 +8077,9 @@
       }
     },
     "node_modules/picnic-api": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.0.0.tgz",
-      "integrity": "sha512-cjP25V0Kx7WeYI4bZ14DLM2F+XdCeL8kydPkRvMpl8Ih3tiaTl7HzqPRP2eATDimm0UXcii55u3R1ovT9qSv6g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.4.0.tgz",
+      "integrity": "sha512-9Z+S0f+dvoC4rX901n7BEAU9UmGGd6Kb9FxI4fzScxcUsF3wVycohnQqVApNdr9UE5O3ENibip7oCWAKkXYGiw==",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.3.0"
@@ -8804,7 +8794,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9627,7 +9616,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9833,7 +9821,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9901,7 +9888,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10286,7 +10272,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10832,7 +10817,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11201,7 +11185,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
       "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "picnic-api": "^4.0.0",
+    "picnic-api": "^4.4.0",
     "zod": "^3.24.4",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,9 @@ const configSchema = z.object({
     .default("3000"),
   HTTP_HOST: z.string().default("localhost"),
   PICNIC_SESSION_FILE: z.string().default(defaultSessionFile),
+  PICNIC_DEVICE_ID: z.string().optional(),
+  PICNIC_DEVICE_FILE: z.string().default(path.join(os.homedir(), ".picnic-device.json")),
+  PICNIC_AGENT: z.string().optional(),
 })
 
 export const config = configSchema.parse(process.env)

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -614,8 +614,9 @@ toolRegistry.register({
         "User-Agent": "okhttp/3.12.2",
         "Content-Type": "application/json; charset=UTF-8",
         ...(authKey && { "x-picnic-auth": authKey }),
-        "x-picnic-agent": "30100;1.15.232-15154",
-        "x-picnic-did": "3C417201548B2E3B",
+        // Use the client's own device/agent headers so 2FA verification matches the login device.
+        "x-picnic-agent": client.picnicHeaders["x-picnic-agent"],
+        "x-picnic-did": client.picnicHeaders["x-picnic-did"],
       },
       body: JSON.stringify({ otp: args.code }),
     })

--- a/src/utils/device-id.ts
+++ b/src/utils/device-id.ts
@@ -1,0 +1,25 @@
+import crypto from "crypto"
+import fs from "fs/promises"
+import { config } from "../config.js"
+
+export async function resolveDeviceId(): Promise<string> {
+  if (config.PICNIC_DEVICE_ID) {
+    return config.PICNIC_DEVICE_ID
+  }
+
+  try {
+    const data = await fs.readFile(config.PICNIC_DEVICE_FILE, "utf-8")
+    const { deviceId } = JSON.parse(data)
+    if (deviceId) return deviceId
+  } catch {
+    // no file yet
+  }
+
+  const deviceId = crypto.randomBytes(8).toString("hex").toUpperCase()
+  try {
+    await fs.writeFile(config.PICNIC_DEVICE_FILE, JSON.stringify({ deviceId }))
+  } catch {
+    // if we cannot persist, still use it for this run
+  }
+  return deviceId
+}

--- a/src/utils/picnic-client.ts
+++ b/src/utils/picnic-client.ts
@@ -1,6 +1,7 @@
 import PicnicClient from "picnic-api"
 import fs from "fs/promises"
 import { config } from "../config.js"
+import { resolveDeviceId } from "./device-id.js"
 
 // Singleton instance for caching
 let picnicClientInstance: InstanceType<typeof PicnicClient> | null = null
@@ -39,11 +40,14 @@ export async function initializePicnicClient(
   const loginCountryCode = countryCode || config.PICNIC_COUNTRY_CODE
 
   const savedAuthKey = await loadSession()
+  const deviceId = await resolveDeviceId()
 
   const client = new PicnicClient({
     countryCode: loginCountryCode,
     apiVersion,
     authKey: savedAuthKey ?? undefined,
+    deviceId,
+    agent: config.PICNIC_AGENT,
   })
 
   if (savedAuthKey) {


### PR DESCRIPTION
Closes #39.

picnic-api v4.4.0 added optional `deviceId` and `agent` parameters to `ApiConfig`. This PR wires them through so every installation uses its own device fingerprint instead of the shared hardcoded `x-picnic-did`.

## Changes
- Bump `picnic-api` to `^4.4.0`.
- New `resolveDeviceId()` (`src/utils/device-id.ts`):
  - uses `PICNIC_DEVICE_ID` if set;
  - otherwise reads a persisted id from `PICNIC_DEVICE_FILE` (default `~/.picnic-device.json`);
  - otherwise generates a random 16-char uppercase hex id and persists it.
- Pass `deviceId` and optional `PICNIC_AGENT` to the `PicnicClient` constructor (`agent` left undefined falls back to picnic-api''s default).
- 2FA verify (`picnic_verify_2fa_code`) now uses the client''s own `x-picnic-did` / `x-picnic-agent` headers instead of a hardcoded device id, so verification matches the login device.

## New config
- `PICNIC_DEVICE_ID` (optional) — fixed device id.
- `PICNIC_DEVICE_FILE` (optional) — where the auto-generated id is persisted.
- `PICNIC_AGENT` (optional) — app agent string.

Fully backwards compatible: with no configuration each install gets a stable auto-generated per-install id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)