### PR TITLE
fix: make build work on Windows (chmod unavailable)

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,5 @@
 import * as esbuild from "esbuild";
+import { chmodSync, existsSync } from "fs";
 await esbuild.build({
   entryPoints: ["./src/index.ts"],
   bundle: true,
@@ -10,3 +11,20 @@ await esbuild.build({
     js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);`,
   },
 });
+
+// The declared CLI entrypoint must exist, otherwise the package would publish a
+// broken bin mapping. Assert it before touching permissions.
+const binPath = "bin/mcp-server.js";
+if (!existsSync(binPath)) {
+  throw new Error(`CLI entrypoint ${binPath} is missing; cannot complete build`);
+}
+
+// Set the POSIX executable bit. On Windows / filesystems without POSIX
+// permissions chmod is unsupported; ignore only that case and rethrow the rest.
+try {
+  chmodSync(binPath, 0o755);
+} catch (err) {
+  if (err.code !== "ENOSYS" && err.code !== "EPERM") {
+    throw err;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bin"
   ],
   "scripts": {
-    "build": "node build.js && chmod +x bin/mcp-server.js",
+    "build": "node build.js",
     "clean": "rm -rf dist",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint --fix src/**/*.ts",


### PR DESCRIPTION
The build script ran `chmod +x bin/mcp-server.js`, which fails on Windows because `chmod` is not available there. This breaks `npm install` (via the `prepare` hook) and `npm run build` on Windows.

This moves the executable bit into `build.js` using `fs.chmodSync` wrapped in try/catch: it still sets the POSIX executable bit on Unix and is a harmless no-op on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
