### PR TITLE
feat(recipes): add recipe tools (fetch, browse, cookbook, cart)

### DIFF
--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1,6 +1,13 @@
 import { z } from "zod"
 import { toolRegistry } from "./registry.js"
 import { getPicnicClient, initializePicnicClient, saveSession } from "../utils/picnic-client.js"
+import {
+  resolveRecipeId,
+  parseSellingGroupRecipe,
+  parseRecipeList,
+  buildRecipeSourceUrl,
+} from "../utils/recipe-parser.js"
+import { config } from "../config.js"
 
 /**
  * Picnic API tools optimized for LLM consumption
@@ -210,6 +217,237 @@ toolRegistry.register({
       size: args.size,
       image,
     }
+  },
+})
+
+// Recipe tools
+//
+// Picnic recipes are "selling groups". Recipe detail comes from
+// /pages/selling-group-details-page?selling_group_id=<id>, and the cookbook /
+// recipe overview from /pages/cookbook-page-content. These page routes are
+// called directly via sendRequest because the picnic-api recipe.* page methods
+// target outdated ids (recipe-details-page-root) that the API answers with 404.
+
+// Base URL for recipe/product image derivatives, derived from the API URL, e.g.
+// https://storefront-prod.de.picnicinternational.com/static/images
+function recipeImageBaseUrl(client: ReturnType<typeof getPicnicClient>): string {
+  return client.url.replace(/\/api\/.*$/, "/static/images")
+}
+
+async function fetchCookbookRecipes(client: ReturnType<typeof getPicnicClient>) {
+  const page = await client.sendRequest("GET", "/pages/cookbook-page-content", null, true)
+  return parseRecipeList(page, { imageBaseUrl: recipeImageBaseUrl(client) })
+}
+
+function paginateRecipes(all: ReturnType<typeof parseRecipeList>, offset: number, limit: number) {
+  const startIndex = offset || 0
+  const recipes = all.slice(startIndex, startIndex + limit).map((recipe) => ({
+    ...recipe,
+    sourceUrl: buildRecipeSourceUrl(config.PICNIC_COUNTRY_CODE, recipe.recipeId),
+  }))
+  return {
+    recipes,
+    pagination: {
+      offset: startIndex,
+      limit,
+      returned: recipes.length,
+      total: all.length,
+      hasMore: startIndex + limit < all.length,
+    },
+  }
+}
+
+// Get recipe tool
+const getRecipeInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe(
+      "A Picnic recipe URL (any format) or a 24-character hex recipe ID. " +
+        "Examples: 'https://picnic.app/de/go/abc123', " +
+        "'https://picnic.app/de/rezepte/0123456789abcdef01234567/example-recipe', " +
+        "'0123456789abcdef01234567'",
+    ),
+})
+
+toolRegistry.register({
+  name: "picnic_get_recipe",
+  description:
+    "Fetch a Picnic recipe by URL or recipe ID. Returns structured recipe data: name, " +
+    "description, ingredients, preparation steps, timing, servings, image URL, saved state, " +
+    "and the canonical source URL. Accepts short share links (picnic.app/de/go/xxx), full " +
+    "recipe URLs, or bare recipe IDs.",
+  inputSchema: getRecipeInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    const page = await client.sendRequest(
+      "GET",
+      `/pages/selling-group-details-page?selling_group_id=${encodeURIComponent(recipeId)}`,
+      null,
+      true,
+    )
+    const parsed = parseSellingGroupRecipe(page, { imageBaseUrl: recipeImageBaseUrl(client) })
+    const sourceUrl = buildRecipeSourceUrl(config.PICNIC_COUNTRY_CODE, recipeId)
+    return { recipeId, sourceUrl, ...parsed }
+  },
+})
+
+// Browse / saved recipes
+const recipeListInputSchema = z.object({
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .default(25)
+    .describe("Maximum number of recipes to return (1-100, default: 25)"),
+  offset: z
+    .number()
+    .min(0)
+    .default(0)
+    .describe("Number of recipes to skip for pagination (default: 0)"),
+})
+
+toolRegistry.register({
+  name: "picnic_browse_recipes",
+  description:
+    "Browse Picnic's recipe/cookbook overview to discover recipes. Returns a paginated list " +
+    "of recipes (id, name, image URL, cookbook section, source URL). Use the recipeId with " +
+    "picnic_get_recipe for full details.",
+  inputSchema: recipeListInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const all = await fetchCookbookRecipes(client)
+    return paginateRecipes(all, args.offset ?? 0, args.limit ?? 25)
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_get_saved_recipes",
+  description:
+    "List the recipes the user has saved/favourited in their Picnic cookbook (the " +
+    "'Gespeichert' tab), distinct from the public discovery feed. Returns id, name, image URL " +
+    "and source URL — useful for importing saved recipes elsewhere.",
+  inputSchema: recipeListInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const all = await fetchCookbookRecipes(client)
+    const saved = all.filter((recipe) => recipe.segments.includes("SAVED_RECIPES"))
+    return paginateRecipes(saved, args.offset ?? 0, args.limit ?? 25)
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_get_own_recipes",
+  description:
+    "List the user's own recipes (the cookbook 'Eigene Rezepte' tab — user-created recipes). " +
+    "Returns id, name, image URL and source URL.",
+  inputSchema: recipeListInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const all = await fetchCookbookRecipes(client)
+    const own = all.filter((recipe) => recipe.segments.includes("USER_DEFINED_RECIPES"))
+    return paginateRecipes(own, args.offset ?? 0, args.limit ?? 25)
+  },
+})
+
+// Save / unsave recipe
+const recipeRefInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe("A Picnic recipe URL (any format) or a 24-character hex recipe ID."),
+})
+
+toolRegistry.register({
+  name: "picnic_save_recipe",
+  description: "Save a recipe to the user's Picnic cookbook, by URL or recipe ID.",
+  inputSchema: recipeRefInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/recipe-saving",
+      { payload: { recipe_id: recipeId, saved_at: new Date().toISOString() } },
+      true,
+    )
+    return { message: "Recipe saved", recipeId }
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_unsave_recipe",
+  description: "Remove a recipe from the user's Picnic cookbook, by URL or recipe ID.",
+  inputSchema: recipeRefInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/recipe-saving",
+      { payload: { recipe_id: recipeId, saved_at: null } },
+      true,
+    )
+    return { message: "Recipe removed from cookbook", recipeId }
+  },
+})
+
+// Add a recipe's ingredients to the basket by assigning the selling group.
+const addRecipeToCartInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe("A Picnic recipe URL (any format) or a 24-character hex recipe ID."),
+  portions: z
+    .number()
+    .min(1)
+    .optional()
+    .describe("Number of portions to add (defaults to the recipe's default portions)."),
+})
+
+toolRegistry.register({
+  name: "picnic_add_recipe_to_cart",
+  description:
+    "Add a recipe's ingredients to the shopping cart by assigning the recipe (selling group) " +
+    "to the basket. Optionally set the number of portions.",
+  inputSchema: addRecipeToCartInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    const payload: { selling_group_id: string; portions?: number } = { selling_group_id: recipeId }
+    if (args.portions !== undefined) payload.portions = args.portions
+    await client.sendRequest("POST", "/pages/task/assign-selling-group-to-basket", { payload }, true)
+    return {
+      message: "Recipe added to cart",
+      recipeId,
+      ...(args.portions !== undefined && { portions: args.portions }),
+    }
+  },
+})
+
+// Remove a recipe's ingredients from the basket (inverse of add_recipe_to_cart).
+toolRegistry.register({
+  name: "picnic_remove_recipe_from_cart",
+  description:
+    "Remove a recipe (selling group) from the basket, undoing picnic_add_recipe_to_cart. " +
+    "Removes only that recipe's ingredients, leaving the rest of the cart untouched.",
+  inputSchema: recipeRefInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/remove-selling-group-from-basket",
+      { payload: { selling_group_id: recipeId } },
+      true,
+    )
+    return { message: "Recipe removed from cart", recipeId }
   },
 })
 

--- a/src/utils/recipe-parser.ts
+++ b/src/utils/recipe-parser.ts
@@ -1,0 +1,677 @@
+/**
+ * Picnic recipe parsing.
+ *
+ * Picnic models recipes as "selling groups" — a recipe id IS a
+ * `selling_group_id`. The mobile API serves a recipe as a Fusion (PML) page at
+ * `GET /pages/selling-group-details-page?selling_group_id=<id>`, and the
+ * recipe/cookbook overview at `GET /pages/cookbook-page-content`. (The older
+ * `recipe-details-page-root` / `recipe_id` route returns 404.)
+ *
+ * Extraction is structured-first and therefore language-agnostic: name,
+ * description, hero image, portions and saved-state come from typed
+ * `selling_group_*_data` fields embedded in the page's SUSPENSE `parameters`.
+ * Ingredient lines and preparation steps are read from the rendered RICH_TEXT
+ * stream, delimited by the localized "Zutaten/Ingrediënten/Ingrédients"
+ * (ingredients) and "Zubereitung/Bereiding/Préparation/So wird's gemacht"
+ * (instructions) section headers, with steps anchored on the per-step
+ * "Schritt/Stap/Étape N" labels so unrelated product cards never leak in.
+ *
+ * Cookbook tiles carry a typed `segment_type` (SAVED_RECIPES,
+ * USER_DEFINED_RECIPES, NEW_RECIPES, …) used to group recipes by tab.
+ */
+
+/** Structured recipe data extracted from a Picnic selling-group recipe page. */
+export interface ParsedRecipe {
+  name: string | null
+  description: string | null
+  /** Short marketing tag, e.g. "Schnell und einfach". */
+  qualityCue: string | null
+  prepTime: string | null
+  /** e.g. "20 min" (total). */
+  totalTime: string | null
+  /** e.g. "2 Portionen". */
+  servings: string | null
+  imageUrl: string | null
+  /** Whether the recipe is saved to the user's cookbook (when known). */
+  isSaved: boolean | null
+  /** Recipe ingredient lines, e.g. ["Paprika 1 Stk.", "Basmatireis 100 g"]. */
+  ingredients: string[]
+  /** "Bring your own" pantry items (the "Eigene Zutaten" line). */
+  pantryIngredients: string[]
+  /** Equipment needed (the "Du benötigst" line), e.g. ["Bratpfanne"]. */
+  tools: string[]
+  /** Editorial tips (the "Tipp" section), not cooking steps. */
+  tips: string[]
+  /** Preparation step texts in order. */
+  instructions: string[]
+}
+
+/** {@link ParsedRecipe} plus the identifiers needed to ingest it elsewhere. */
+export interface PicnicRecipeResult extends ParsedRecipe {
+  /** 24-char hex recipe id (a selling_group_id). */
+  recipeId: string
+  /** Canonical picnic.app recipe URL. */
+  sourceUrl: string
+}
+
+/** A single recipe entry from the cookbook / recipe overview. */
+export interface RecipeListItem {
+  recipeId: string
+  name: string | null
+  imageUrl: string | null
+  /** Cookbook segments the recipe belongs to (e.g. ["SAVED_RECIPES"]). */
+  segments: string[]
+}
+
+// ── Recipe ID resolution ─────────────────────────────────────────────────────
+
+// A recipe id (selling_group_id) is 24 hex chars for catalog recipes and 32 for
+// the user's own (user-defined) recipes.
+const RECIPE_ID_RE = /^[a-f0-9]{24,32}$/
+// A recipe id as a URL path segment (DE rezepte / NL recepten / FR recettes).
+const RECIPE_ID_IN_URL_RE = /\/([a-f0-9]{24,32})(?:[/?#]|$)/
+// `selling_group_id=<id>` (or the legacy `recipe_id=<id>`) in a deep link.
+const ID_PARAM_RE = /(?:selling_group_id|recipe_id)=([a-f0-9]{24,32})/
+// Any recipe id reference, used when grouping cookbook tiles by segment.
+const ANY_ID_REF_RE = /(?:selling_group_id|recipe_id|recipeIds)=([a-f0-9]{24,32})/g
+
+const RECIPE_PATH_BY_COUNTRY: Record<string, string> = {
+  NL: "recepten",
+  DE: "rezepte",
+  FR: "recettes",
+}
+
+/**
+ * Build the canonical picnic.app recipe URL for a given country and recipe ID.
+ * Falls back to a neutral `recipes` path segment for unknown country codes.
+ */
+export function buildRecipeSourceUrl(countryCode: string, recipeId: string): string {
+  const segment = RECIPE_PATH_BY_COUNTRY[countryCode.toUpperCase()] ?? "recipes"
+  return `https://picnic.app/${countryCode.toLowerCase()}/${segment}/${recipeId}`
+}
+
+const ALLOWED_SHARE_HOSTS = new Set(["picnic.app"])
+
+function isAllowedShareHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return ALLOWED_SHARE_HOSTS.has(host) || host.endsWith(".picnic.app")
+}
+
+function assertAllowedShareUrl(raw: string): URL {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error(`Not a valid recipe URL: ${raw}`)
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`Refusing to resolve a non-https recipe URL: ${raw}`)
+  }
+  if (!isAllowedShareHost(url.hostname)) {
+    throw new Error(`Refusing to resolve a recipe URL outside picnic.app: ${url.hostname}`)
+  }
+  return url
+}
+
+/**
+ * Resolve a Picnic recipe URL (any format) or bare recipe id to a 24-char hex
+ * recipe id (a selling_group_id). The redirect-following request for short
+ * share links is restricted to `picnic.app` hosts over HTTPS (host re-checked
+ * after redirects) so it cannot be steered at arbitrary/internal hosts.
+ */
+export async function resolveRecipeId(input: string): Promise<string> {
+  const trimmed = input.trim()
+
+  if (RECIPE_ID_RE.test(trimmed)) return trimmed
+
+  const longMatch = trimmed.match(RECIPE_ID_IN_URL_RE)
+  if (longMatch) return longMatch[1]
+
+  const paramMatch = trimmed.match(ID_PARAM_RE)
+  if (paramMatch) return paramMatch[1]
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    const startUrl = assertAllowedShareUrl(trimmed)
+    const res = await fetch(startUrl.href, { method: "HEAD", redirect: "follow" })
+    const finalUrl = new URL(res.url || startUrl.href)
+    if (!isAllowedShareHost(finalUrl.hostname)) {
+      throw new Error(
+        `Recipe share link redirected off picnic.app to ${finalUrl.hostname}; refusing to follow`,
+      )
+    }
+    const resolvedMatch = finalUrl.href.match(RECIPE_ID_IN_URL_RE) ?? finalUrl.href.match(ID_PARAM_RE)
+    if (resolvedMatch) return resolvedMatch[1]
+  }
+
+  throw new Error(`Cannot extract a Picnic recipe id from: ${input}`)
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Object keys carrying actions/analytics/fallback UI rather than content. */
+const SKIP_KEYS = new Set([
+  "analytics",
+  "tracking_attributes",
+  "loadingConfig",
+  "errorConfig",
+  "placeholder",
+  "fallbackSource",
+  "presets",
+  "viewabilityListeners",
+])
+
+/** Strip Picnic colour markup, markdown action links and emphasis from a line. */
+function cleanLine(line: string): string {
+  return line
+    .replace(/#\(#[0-9a-fA-F]{6}\)/g, "")
+    .replace(/\[([^\]]+)\]\((?:action|app|https?):\/\/[^)]*\)/g, "$1")
+    .replace(/^\s*#{1,6}\s+/, "")
+    .replace(/^\s*[-*+]\s+/, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+// ── Localized section / label matchers ───────────────────────────────────────
+
+const INGREDIENT_HEADER_RE = /^(zutaten|ingredi[eë]nten|ingr[eé]dients?)$/i
+const INSTRUCTION_HEADER_RE =
+  /^(zubereitung(sschritte)?|anleitung|so wird.?s gemacht|bereiding(swijze)?|zo maak je het|pr[eé]paration|instructions?)$/i
+const STEP_LABEL_RE = /^(schritt|stap|[ée]tape|step)\s*\d+$/i
+const TIP_HEADER_RE = /^(tipps?|tips?|astuces?)$/i
+const TIME_RE = /\b\d+\s*min\b/i
+const TOTAL_TIME_RE = /\b(gesamt|insgesamt|total|totaal)\b/i
+const SERVINGS_RE = /\b(portion(en|s)?|porties|personen|personnes?)\b|\b\d+\s*pers\b/i
+// A clean servings *value* — a leading count plus a unit. Used to set the
+// servings field, so a nutrition header like "1 Portion des Originalrezepts
+// enthält ungefähr:" (which contains "Portion") is not mistaken for it.
+const SERVINGS_VALUE_RE = /^\d+\s*(portion(en|s)?|porties|personen|personnes?|pers\.?)$/i
+const NUMBER_ONLY_RE = /^\d+[.)]?$/
+const PANTRY_LINE_RE = /^(eigene zutaten|eigen recept|own ingredients|propres ingr[ée]dients?)\s*:\s*(.+)$/i
+const TOOLS_LINE_RE = /^(du ben[öo]tigst|je hebt nodig|you.?ll need|tu auras besoin)\s*:\s*(.+)$/i
+const BUTTON_WORDS = new Set([
+  "ansehen",
+  "hinzufügen",
+  "view",
+  "add",
+  "bekijken",
+  "toevoegen",
+  "voir",
+  "ajouter",
+])
+
+function splitMetaLine(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+// ── Structured (language-agnostic) extraction ────────────────────────────────
+
+interface StructuredRecipe {
+  name: string | null
+  description: string | null
+  qualityCue: string | null
+  imageId: string | null
+  imageNamespace: string | null
+  portions: number | null
+  isSaved: boolean | null
+}
+
+function collectStructured(page: unknown): StructuredRecipe {
+  const out: StructuredRecipe = {
+    name: null,
+    description: null,
+    qualityCue: null,
+    imageId: null,
+    imageNamespace: null,
+    portions: null,
+    isSaved: null,
+  }
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+
+    const title = n.selling_group_title_section_data
+    if (isRecord(title)) {
+      if (typeof title.name === "string") out.name = out.name ?? title.name
+      if (typeof title.description === "string")
+        out.description = out.description ?? title.description
+      if (typeof title.quality_cue === "string")
+        out.qualityCue = out.qualityCue ?? title.quality_cue
+    }
+
+    const header = n.selling_group_header_data
+    if (isRecord(header)) {
+      if (typeof header.is_saved === "boolean") out.isSaved = out.isSaved ?? header.is_saved
+      if (typeof header.sellable_name === "string") out.name = out.name ?? header.sellable_name
+      if (out.portions === null && typeof header.default_portions === "number")
+        out.portions = header.default_portions
+    }
+
+    const image = n.selling_group_image_data
+    if (isRecord(image)) {
+      const imgs = isRecord(image.images) ? image.images.images : undefined
+      if (Array.isArray(imgs)) {
+        const primary = imgs.find((x) => isRecord(x) && x.primary) ?? imgs[0]
+        if (isRecord(primary)) {
+          if (typeof primary.id === "string") out.imageId = out.imageId ?? primary.id
+          if (typeof primary.namespace === "string")
+            out.imageNamespace = out.imageNamespace ?? primary.namespace
+        }
+      }
+    }
+
+    if (typeof n.portions === "number") out.portions = n.portions
+
+    for (const v of Object.values(n)) visit(v)
+  }
+  visit(page)
+  return out
+}
+
+/** Collect cleaned RICH_TEXT lines in document order (skipping metadata keys). */
+function collectTextTokens(page: unknown): string[] {
+  const tokens: string[] = []
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.type === "RICH_TEXT" && typeof n.markdown === "string") {
+      for (const raw of n.markdown.split("\n")) {
+        const value = cleanLine(raw)
+        if (value) tokens.push(value)
+      }
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(page)
+  return tokens
+}
+
+function buildImageUrl(
+  imageId: string | null,
+  namespace: string | null,
+  imageBaseUrl?: string,
+): string | null {
+  if (!imageId || !imageBaseUrl) return null
+  const path = namespace && !imageId.includes("/") ? `${namespace}/${imageId}` : imageId
+  return `${imageBaseUrl.replace(/\/$/, "")}/${path}/large.png`
+}
+
+export interface ParseRecipeOptions {
+  /** Base for recipe image URLs, e.g. `https://storefront-prod.de…/static/images`. */
+  imageBaseUrl?: string
+}
+
+/**
+ * Parse a Picnic selling-group recipe page into structured recipe data. Returns
+ * an all-null/empty {@link ParsedRecipe} for unrecognized input rather than
+ * throwing. Robust to personalized/scaled recipes, whose pages interleave
+ * product cards, nutrition and allergen blocks with the recipe content.
+ */
+export function parseSellingGroupRecipe(page: unknown, opts: ParseRecipeOptions = {}): ParsedRecipe {
+  const struct = collectStructured(page)
+  const result: ParsedRecipe = {
+    name: struct.name,
+    description: struct.description,
+    qualityCue: struct.qualityCue,
+    prepTime: null,
+    totalTime: null,
+    servings: struct.portions !== null ? String(struct.portions) : null,
+    imageUrl: buildImageUrl(struct.imageId, struct.imageNamespace, opts.imageBaseUrl),
+    isSaved: struct.isSaved,
+    ingredients: [],
+    pantryIngredients: [],
+    tools: [],
+    tips: [],
+    instructions: [],
+  }
+
+  const tokens = collectTextTokens(page)
+
+  // Section anchors. The instruction header must come AFTER the ingredient
+  // header, so a stray product-card "Zubereitung" tab does not hijack it.
+  let ingredientStart = -1
+  let tipStart = -1
+  const stepIdx: number[] = []
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (ingredientStart < 0 && INGREDIENT_HEADER_RE.test(t)) ingredientStart = i
+    if (STEP_LABEL_RE.test(t)) stepIdx.push(i)
+    if (tipStart < 0 && TIP_HEADER_RE.test(t)) tipStart = i
+  }
+  let instructionStart = -1
+  for (let i = 0; i < tokens.length; i++) {
+    if (INSTRUCTION_HEADER_RE.test(tokens[i]) && (ingredientStart < 0 || i > ingredientStart)) {
+      instructionStart = i
+      break
+    }
+  }
+
+  // Timing: only in the meta region (before the instructions/steps), so a step
+  // that mentions a duration isn't mistaken for the recipe time.
+  const metaEnd =
+    instructionStart >= 0 ? instructionStart : stepIdx.length > 0 ? stepIdx[0] : tokens.length
+  for (let i = 0; i < metaEnd; i++) {
+    const t = tokens[i]
+    if (!TIME_RE.test(t)) continue
+    const next = tokens[i + 1] ?? ""
+    if (TOTAL_TIME_RE.test(t) || TOTAL_TIME_RE.test(next)) result.totalTime = result.totalTime ?? t
+    else result.prepTime = result.prepTime ?? t
+  }
+
+  // Servings: a clean "N Portionen" value anywhere (the structured portion
+  // count from collectStructured is the fallback).
+  for (const t of tokens) {
+    if (SERVINGS_VALUE_RE.test(t)) {
+      result.servings = t
+      break
+    }
+  }
+
+  // Ingredients: between the ingredient header and the instruction header,
+  // splitting out the "Eigene Zutaten" (pantry) and "Du benötigst" (tools) lines.
+  const ingEnd = instructionStart >= 0 ? instructionStart : tokens.length
+  if (ingredientStart >= 0) {
+    for (let i = ingredientStart + 1; i < ingEnd; i++) {
+      const t = tokens[i]
+      if (NUMBER_ONLY_RE.test(t) || t.length < 2 || BUTTON_WORDS.has(t.toLowerCase())) continue
+      const pantry = PANTRY_LINE_RE.exec(t)
+      if (pantry) {
+        result.pantryIngredients.push(...splitMetaLine(pantry[2]))
+        continue
+      }
+      const tools = TOOLS_LINE_RE.exec(t)
+      if (tools) {
+        result.tools.push(...splitMetaLine(tools[2]))
+        continue
+      }
+      if (SERVINGS_RE.test(t)) continue
+      result.ingredients.push(t)
+    }
+  }
+
+  // Instructions: anchored on the "Schritt N" labels (robust); otherwise fall
+  // back to the text after the instruction header, stopping at the tips block.
+  if (stepIdx.length > 0) {
+    const bounds = [...stepIdx, tipStart >= 0 ? tipStart : tokens.length, tokens.length]
+    for (const si of stepIdx) {
+      const next = Math.min(...bounds.filter((b) => b > si))
+      const body: string[] = []
+      for (let k = si + 1; k < next; k++) {
+        const t = tokens[k]
+        if (
+          STEP_LABEL_RE.test(t) ||
+          SERVINGS_RE.test(t) ||
+          NUMBER_ONLY_RE.test(t) ||
+          t.length < 2 ||
+          BUTTON_WORDS.has(t.toLowerCase())
+        )
+          continue
+        body.push(t)
+      }
+      if (body.length > 0) result.instructions.push(body.join(" "))
+    }
+  } else if (instructionStart >= 0) {
+    for (let k = instructionStart + 1; k < tokens.length; k++) {
+      const t = tokens[k]
+      if (TIP_HEADER_RE.test(t)) break
+      if (
+        SERVINGS_RE.test(t) ||
+        NUMBER_ONLY_RE.test(t) ||
+        STEP_LABEL_RE.test(t) ||
+        t.length < 2 ||
+        BUTTON_WORDS.has(t.toLowerCase())
+      )
+        continue
+      result.instructions.push(t)
+    }
+  }
+
+  // Tips: editorial notes after the "Tipp" header.
+  if (tipStart >= 0) {
+    for (let k = tipStart + 1; k < tokens.length; k++) {
+      const t = tokens[k]
+      if (t.length >= 2 && !BUTTON_WORDS.has(t.toLowerCase())) result.tips.push(t)
+    }
+  }
+
+  return result
+}
+
+// ── Cookbook list parsing (grouped by segment) ───────────────────────────────
+
+function findSegmentType(analytics: unknown): string | null {
+  const match = JSON.stringify(analytics).match(/"segment_type"\s*:\s*"([^"]+)"/)
+  return match ? match[1] : null
+}
+
+/**
+ * Map every recipe id in a cookbook page to the set of segment types it belongs
+ * to (SAVED_RECIPES, USER_DEFINED_RECIPES, NEW_RECIPES, …). Segment membership
+ * lives in the `segment_type` analytics on each tile/shelf, alongside the
+ * recipe's `selling_group_id` (single tiles) or `recipeIds` list (see-more).
+ */
+function collectSegmentsById(page: unknown): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>()
+  const add = (id: string, seg: string): void => {
+    const existing = map.get(id)
+    if (existing) existing.add(seg)
+    else map.set(id, new Set([seg]))
+  }
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.analytics !== undefined) {
+      const seg = findSegmentType(n.analytics)
+      if (seg) {
+        for (const m of JSON.stringify(n).matchAll(ANY_ID_REF_RE)) add(m[1], seg)
+        return
+      }
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (key === "analytics" || SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(page)
+  return map
+}
+
+function findLinkedRecipeId(node: unknown, depth: number): string | null {
+  if (depth > 8 || node === null || node === undefined) return null
+  if (typeof node === "string") {
+    const m = node.match(ID_PARAM_RE)
+    return m ? m[1] : null
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const id = findLinkedRecipeId(child, depth + 1)
+      if (id) return id
+    }
+    return null
+  }
+  if (!isRecord(node)) return null
+  for (const v of Object.values(node)) {
+    const id = findLinkedRecipeId(v, depth + 1)
+    if (id) return id
+  }
+  return null
+}
+
+/** Longest free-text RICH_TEXT line under a node (the recipe name, not a tag). */
+function firstRecipeNameIn(node: unknown): string | null {
+  const labels = new Set(["hinzufügen", "nicht alles vorrätig", "add", "toevoegen", "ajouter"])
+  let best: string | null = null
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.type === "RICH_TEXT" && typeof n.markdown === "string") {
+      for (const raw of n.markdown.split("\n")) {
+        const v = cleanLine(raw)
+        if (
+          v.length > 6 &&
+          v.length <= 90 &&
+          !labels.has(v.toLowerCase()) &&
+          !TIME_RE.test(v) &&
+          !SERVINGS_RE.test(v) &&
+          (best === null || v.length > best.length)
+        ) {
+          best = v
+        }
+      }
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (key === "onPress" || SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(node)
+  return best
+}
+
+function firstImageIn(node: unknown): { id: string; namespace: string | null } | null {
+  let found: { id: string; namespace: string | null } | null = null
+  const visit = (n: unknown): void => {
+    if (found) return
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.type === "IMAGE" && isRecord(n.source) && typeof n.source.id === "string") {
+      const ns = typeof n.source.namespace === "string" ? n.source.namespace : null
+      found = { id: n.source.id, namespace: ns }
+      return
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (key === "onPress" || SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(node)
+  return found
+}
+
+function hasRecipeTileAnalytics(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(hasRecipeTileAnalytics)
+  if (!isRecord(node)) return false
+  // `recipe_tile` is a catalog tile; `recipe_tile_mini` is a user-defined-recipe tile.
+  if (node.type === "recipe_tile" || node.type === "recipe_tile_mini") return true
+  return Object.values(node).some(hasRecipeTileAnalytics)
+}
+
+// Recipe names are also carried in `recipe` analytics contexts
+// ({recipe_id, recipe_name}) — the reliable source for user-defined recipes,
+// whose name is only present there (often inside an EXPRESSION string), not as
+// a rendered RICH_TEXT tile.
+const RECIPE_NAME_CONTEXT_RE =
+  /"recipe_id"\s*:\s*"([a-f0-9]{24,32})"[\s\S]{0,160}?"recipe_name"\s*:\s*"([^"]+)"/g
+
+function collectRecipeNames(page: unknown): Map<string, string> {
+  const map = new Map<string, string>()
+  const visit = (n: unknown): void => {
+    if (typeof n === "string") {
+      for (const m of n.matchAll(RECIPE_NAME_CONTEXT_RE)) if (!map.has(m[1])) map.set(m[1], m[2])
+      return
+    }
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (
+      typeof n.recipe_id === "string" &&
+      typeof n.recipe_name === "string" &&
+      !map.has(n.recipe_id)
+    ) {
+      map.set(n.recipe_id, n.recipe_name)
+    }
+    for (const v of Object.values(n)) visit(v)
+  }
+  visit(page)
+  return map
+}
+
+/** Collect rendered recipe tiles → name/image by recipe id. */
+function collectTileInfo(
+  page: unknown,
+  opts: ParseRecipeOptions,
+): Map<string, { name: string | null; imageUrl: string | null }> {
+  const info = new Map<string, { name: string | null; imageUrl: string | null }>()
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.analytics !== undefined && hasRecipeTileAnalytics(n.analytics)) {
+      const recipeId = findLinkedRecipeId(n, 0)
+      if (recipeId && !info.has(recipeId)) {
+        const img = firstImageIn(n)
+        info.set(recipeId, {
+          name: firstRecipeNameIn(n),
+          imageUrl: img ? buildImageUrl(img.id, img.namespace, opts.imageBaseUrl) : null,
+        })
+      }
+      return
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(page)
+  return info
+}
+
+/**
+ * Parse a cookbook / recipe-overview page into a flat list of recipe entries,
+ * each tagged with the cookbook segments it belongs to. Names and images come
+ * from the rendered tiles; recipes that exist only in a segment list (e.g.
+ * saved/own recipes not currently rendered) are still included, without a name.
+ */
+export function parseRecipeList(page: unknown, opts: ParseRecipeOptions = {}): RecipeListItem[] {
+  const segById = collectSegmentsById(page)
+  const tileInfo = collectTileInfo(page, opts)
+  const names = collectRecipeNames(page)
+  const out: RecipeListItem[] = []
+  const seen = new Set<string>()
+
+  for (const [id, segs] of segById) {
+    seen.add(id)
+    const info = tileInfo.get(id)
+    out.push({
+      recipeId: id,
+      name: info?.name ?? names.get(id) ?? null,
+      imageUrl: info?.imageUrl ?? null,
+      segments: [...segs],
+    })
+  }
+  for (const [id, info] of tileInfo) {
+    if (seen.has(id)) continue
+    out.push({ recipeId: id, name: info.name ?? names.get(id) ?? null, imageUrl: info.imageUrl, segments: [] })
+  }
+  return out
+}

--- a/test/unit/utils/recipe-parser.test.ts
+++ b/test/unit/utils/recipe-parser.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import {
+  resolveRecipeId,
+  parseSellingGroupRecipe,
+  parseRecipeList,
+  buildRecipeSourceUrl,
+} from "../../../src/utils/recipe-parser.js"
+
+const RECIPE_ID = "0123456789abcdef01234567"
+// User-defined recipe ids are 32 hex chars (catalog recipe ids are 24).
+const OWN_ID = "fedcba9876543210fedcba9876543210"
+const NEW_ID = "aaaaaaaaaaaaaaaaaaaaaaaa"
+const IMAGE_BASE = "https://cdn.example/static/images"
+
+function richText(markdown: string) {
+  return { type: "RICH_TEXT", markdown }
+}
+
+function suspense(parameters: Record<string, unknown>) {
+  return { type: "SUSPENSE", suspenseId: "s", pageConfig: { id: "selling-group-x", parameters } }
+}
+
+function detailPage(lines: string[], structured: Record<string, unknown>[]) {
+  return {
+    id: "selling-group-details-page-root",
+    body: {
+      type: "STATE_BOUNDARY",
+      child: {
+        type: "BLOCK",
+        children: [
+          ...structured.map(suspense),
+          { type: "PML", pml: { component: { type: "STACK", children: lines.map(richText) } } },
+        ],
+      },
+    },
+  }
+}
+
+describe("resolveRecipeId", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("returns a bare recipe id unchanged (24- or 32-char)", async () => {
+    await expect(resolveRecipeId(`  ${RECIPE_ID}  `)).resolves.toBe(RECIPE_ID)
+    await expect(resolveRecipeId(OWN_ID)).resolves.toBe(OWN_ID)
+    await expect(resolveRecipeId(`https://picnic.app/de/rezepte/${OWN_ID}/own`)).resolves.toBe(OWN_ID)
+  })
+
+  it("extracts the id from full recipe URLs across markets and deep links", async () => {
+    await expect(resolveRecipeId(`https://picnic.app/de/rezepte/${RECIPE_ID}/gyros`)).resolves.toBe(RECIPE_ID)
+    await expect(resolveRecipeId(`https://picnic.app/nl/recepten/${RECIPE_ID}/x`)).resolves.toBe(RECIPE_ID)
+    await expect(resolveRecipeId(`https://picnic.app/fr/recettes/${RECIPE_ID}?u=1`)).resolves.toBe(RECIPE_ID)
+    await expect(
+      resolveRecipeId(`app.picnic://store/page;id=selling-group-details-page,selling_group_id=${RECIPE_ID}`),
+    ).resolves.toBe(RECIPE_ID)
+  })
+
+  it("follows a short share link redirect on picnic.app", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ url: `https://picnic.app/de/rezepte/${RECIPE_ID}?path=selling_group_id%3D${RECIPE_ID}` }),
+    )
+    await expect(resolveRecipeId("https://picnic.app/de/go/abc123")).resolves.toBe(RECIPE_ID)
+  })
+
+  it("refuses to request a non-picnic host (SSRF guard)", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(resolveRecipeId("https://10.0.0.5/")).rejects.toThrow(/picnic\.app/)
+    await expect(resolveRecipeId("http://169.254.169.254/")).rejects.toThrow()
+    await expect(resolveRecipeId("http://picnic.app/de/go/x")).rejects.toThrow(/non-https/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("refuses when a picnic.app link redirects off-domain", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ url: "https://evil.example/internal" }))
+    await expect(resolveRecipeId("https://picnic.app/de/go/xxx")).rejects.toThrow(/redirected off/)
+  })
+
+  it("throws when no id can be extracted", async () => {
+    await expect(resolveRecipeId("not-a-recipe")).rejects.toThrow(/Cannot extract/)
+  })
+})
+
+describe("parseSellingGroupRecipe", () => {
+  it("parses a recipe robustly despite a stray product-card 'Zubereitung'", () => {
+    const page = detailPage(
+      [
+        "Gyros-Reispfanne mit Feta",
+        "One-Pot-Favorit",
+        "20 min",
+        "Gesamt",
+        "Zubereitung", // stray product-card tab — must NOT hijack instructions
+        "Paprika Mix",
+        "2.24",
+        "(1 Stk. benötigt)",
+        "1 Portion des Originalrezepts enthält ungefähr:", // nutrition header — must NOT become servings
+        "Zutaten",
+        "**Paprika** 1 Stk.",
+        "**Basmatireis** 100 g",
+        "**Gyros** 250 g",
+        "**Eigene Zutaten:** 0.5 Stk. Knoblauch, Olivenöl, Salz und Pfeffer",
+        "**Du benötigst:** Bratpfanne",
+        "So wird's gemacht",
+        "2 Portionen",
+        "Schritt 1",
+        "Paprika waschen und würfeln.",
+        "Schritt 2",
+        "Gyros anbraten. [Zurück zum Original](action://open-undo)",
+        "Tipp",
+        "Dazu passt ein Salat.",
+      ],
+      [
+        {
+          selling_group_title_section_data: {
+            name: "Gyros-Reispfanne mit Feta",
+            description: "Eine schnelle One-Pot-Reispfanne.",
+            quality_cue: "One-Pot-Favorit",
+          },
+        },
+        { selling_group_image_data: { images: { images: [{ id: "img1", namespace: "recipes", primary: true }] } } },
+        { selling_group_header_data: { is_saved: true, default_portions: 4 } },
+        { portions: 2 },
+      ],
+    )
+
+    const r = parseSellingGroupRecipe(page, { imageBaseUrl: IMAGE_BASE })
+    expect(r.name).toBe("Gyros-Reispfanne mit Feta")
+    expect(r.qualityCue).toBe("One-Pot-Favorit")
+    expect(r.totalTime).toBe("20 min")
+    expect(r.servings).toBe("2 Portionen")
+    expect(r.isSaved).toBe(true)
+    expect(r.imageUrl).toBe(`${IMAGE_BASE}/recipes/img1/large.png`)
+    expect(r.ingredients).toEqual(["Paprika 1 Stk.", "Basmatireis 100 g", "Gyros 250 g"])
+    expect(r.pantryIngredients).toEqual(["0.5 Stk. Knoblauch", "Olivenöl", "Salz und Pfeffer"])
+    expect(r.tools).toEqual(["Bratpfanne"])
+    expect(r.instructions).toEqual([
+      "Paprika waschen und würfeln.",
+      "Gyros anbraten. Zurück zum Original", // action link stripped to its label
+    ])
+    expect(r.tips).toEqual(["Dazu passt ein Salat."])
+  })
+
+  it("parses Dutch and French recipes via localized headers and step labels", () => {
+    const nl = detailPage(
+      ["Ingrediënten", "**Rijst** 200 g", "Bereiding", "4 porties", "Stap 1", "Kook de rijst."],
+      [{ selling_group_title_section_data: { name: "Rijstschotel", description: null } }],
+    )
+    const rnl = parseSellingGroupRecipe(nl)
+    expect(rnl.name).toBe("Rijstschotel")
+    expect(rnl.servings).toBe("4 porties")
+    expect(rnl.ingredients).toEqual(["Rijst 200 g"])
+    expect(rnl.instructions).toEqual(["Kook de rijst."])
+
+    const fr = detailPage(
+      ["Ingrédients", "**Riz** 200 g", "Préparation", "4 personnes", "Étape 1", "Cuire le riz."],
+      [{ selling_group_title_section_data: { name: "Poêlée de riz", description: null } }],
+    )
+    const rfr = parseSellingGroupRecipe(fr)
+    expect(rfr.instructions).toEqual(["Cuire le riz."])
+    expect(rfr.ingredients).toEqual(["Riz 200 g"])
+  })
+
+  it("returns metadata for a recipe with no rendered ingredient/step sections (user-defined recipe)", () => {
+    // User-defined recipes carry structured metadata but no Zutaten/Schritt
+    // RICH_TEXT sections — name must be set and ingredients/steps stay empty.
+    const page = detailPage(
+      ["My Recipe"],
+      [
+        { selling_group_title_section_data: { name: "My Recipe", description: null } },
+        { selling_group_header_data: { is_saved: false, default_portions: 4 } },
+      ],
+    )
+    const r = parseSellingGroupRecipe(page)
+    expect(r.name).toBe("My Recipe")
+    expect(r.isSaved).toBe(false)
+    expect(r.ingredients).toEqual([])
+    expect(r.instructions).toEqual([])
+    expect(r.pantryIngredients).toEqual([])
+  })
+
+  it("returns an empty result for unrecognized input without throwing", () => {
+    const empty = {
+      name: null,
+      description: null,
+      qualityCue: null,
+      prepTime: null,
+      totalTime: null,
+      servings: null,
+      imageUrl: null,
+      isSaved: null,
+      ingredients: [],
+      pantryIngredients: [],
+      tools: [],
+      tips: [],
+      instructions: [],
+    }
+    expect(parseSellingGroupRecipe(null)).toEqual(empty)
+    expect(parseSellingGroupRecipe({})).toEqual(empty)
+  })
+})
+
+describe("parseRecipeList", () => {
+  function cookbookTile(id: string, name: string, segmentType: string, imageId: string) {
+    return {
+      type: "PML",
+      id: `tile-${id}`,
+      analytics: {
+        contexts: [
+          { data: { type: "recipe_tile", template_id: "cookbook-recipe-tile" }, schema: "iglu:x/pml_component/1" },
+          { data: { segment_name: segmentType, segment_type: segmentType }, schema: "iglu:x/segment/1" },
+        ],
+      },
+      pml: {
+        component: {
+          type: "TOUCHABLE",
+          onPress: {
+            type: "EXPRESSION",
+            expression: `onPMLAction({ actionType: "OPEN", target: "app.picnic://store/page;id=selling-group-details-page,selling_group_id=${id}" })`,
+          },
+          child: {
+            type: "STACK",
+            children: [{ type: "IMAGE", source: { id: imageId, namespace: "recipes" } }, richText(name)],
+          },
+        },
+      },
+    }
+  }
+
+  // A user-defined-recipe tile: recipe_tile_mini, name only in the analytics
+  // `recipe` context (inside an EXPRESSION), no rendered RICH_TEXT name.
+  function udrTile(id: string, name: string) {
+    return {
+      type: "CONTAINER",
+      analytics: {
+        contexts: [
+          { data: { type: "recipe_tile_mini", template_id: "core-uds-recipe-tile" }, schema: "iglu:x/pml_component/1" },
+          { data: { recipe_id: id, recipe_image_type: "GALLERY", recipe_name: name }, schema: "iglu:x/recipe/1" },
+          { data: { segment_name: "Eigene Rezepte", segment_type: "USER_DEFINED_RECIPES" }, schema: "iglu:x/segment/1" },
+        ],
+      },
+      child: {
+        type: "TOUCHABLE",
+        onPress: {
+          type: "EXPRESSION",
+          expression: `onPMLAction({ actionType: "OPEN", target: "app.picnic://store/page;id=selling-group-details-page,selling_group_id=${id}" })`,
+        },
+      },
+    }
+  }
+
+  function cookbook(children: unknown[]) {
+    return { id: "cookbook", body: { type: "STATE_BOUNDARY", child: { type: "BLOCK", children } } }
+  }
+
+  it("groups recipes by segment, with names/images from tiles", () => {
+    const page = cookbook([
+      cookbookTile(RECIPE_ID, "Gyros-Reispfanne mit Feta", "SAVED_RECIPES", "abc"),
+      udrTile(OWN_ID, "My Recipe"),
+      cookbookTile(NEW_ID, "Neues Rezept", "NEW_RECIPES", "ghi"),
+    ])
+    const list = parseRecipeList(page, { imageBaseUrl: IMAGE_BASE })
+    expect(list).toHaveLength(3)
+
+    const saved = list.filter((r) => r.segments.includes("SAVED_RECIPES"))
+    expect(saved).toEqual([
+      {
+        recipeId: RECIPE_ID,
+        name: "Gyros-Reispfanne mit Feta",
+        imageUrl: `${IMAGE_BASE}/recipes/abc/large.png`,
+        segments: ["SAVED_RECIPES"],
+      },
+    ])
+
+    const own = list.filter((r) => r.segments.includes("USER_DEFINED_RECIPES"))
+    expect(own.map((r) => [r.recipeId, r.name])).toEqual([[OWN_ID, "My Recipe"]])
+  })
+
+  it("returns an empty list for a page with no recipe tiles", () => {
+    expect(parseRecipeList(cookbook([richText("Hello")]))).toEqual([])
+  })
+})
+
+describe("buildRecipeSourceUrl", () => {
+  it("uses the localized path segment per country, with a neutral fallback", () => {
+    expect(buildRecipeSourceUrl("DE", RECIPE_ID)).toBe(`https://picnic.app/de/rezepte/${RECIPE_ID}`)
+    expect(buildRecipeSourceUrl("NL", RECIPE_ID)).toBe(`https://picnic.app/nl/recepten/${RECIPE_ID}`)
+    expect(buildRecipeSourceUrl("FR", RECIPE_ID)).toBe(`https://picnic.app/fr/recettes/${RECIPE_ID}`)
+    expect(buildRecipeSourceUrl("XX", RECIPE_ID)).toBe(`https://picnic.app/xx/recipes/${RECIPE_ID}`)
+  })
+})


### PR DESCRIPTION
## What

Adds eight recipe tools:

| Tool | Purpose |
|---|---|
| `picnic_get_recipe` | Fetch a recipe by URL or id → structured data: name, description, timing, servings, image, ingredients, preparation steps, pantry items, tools, tips, saved state |
| `picnic_browse_recipes` | List recipes from the cookbook overview, grouped by segment |
| `picnic_get_saved_recipes` | List saved/favourited recipes |
| `picnic_get_own_recipes` | List the user's own (user-defined) recipes |
| `picnic_save_recipe` / `picnic_unsave_recipe` | Manage the cookbook |
| `picnic_add_recipe_to_cart` / `picnic_remove_recipe_from_cart` | Add/remove a recipe's ingredients to/from the basket |

## How

Picnic models recipes as **selling groups** (a recipe id is a `selling_group_id`). Extraction is structured-first and therefore language-agnostic: name, description, image, portions and saved-state come from the typed `selling_group_*_data` fields in the page's SUSPENSE parameters. Ingredient lines and preparation steps are read from the localized RICH_TEXT sections (DE/NL/FR), with steps anchored on the per-step "Schritt/Stap/Étape N" labels and the instruction header required to follow the ingredient header — so personalized/scaled recipes (whose pages interleave product cards, nutrition and allergen blocks) parse cleanly. "Eigene Zutaten"/"Du benötigst"/"Tipp" lines are split into separate `pantryIngredients`/`tools`/`tips` fields. Short-link resolution is restricted to `picnic.app` over HTTPS to avoid SSRF.

Pure parsing logic lives in `src/utils/recipe-parser.ts` with unit tests; the tools register through the existing `toolRegistry` and follow the repo's conventions.

## ⚠️ picnic-api workaround

These tools call the page routes directly via `client.sendRequest()` because `picnic-api`'s `recipe.*` page methods target outdated ids: `getRecipeDetailsPage()` requests `/pages/recipe-details-page-root?recipe_id=<id>`, which the storefront answers with **HTTP 404** at every API version. Recipes are served from `selling-group-details-page` / `cookbook-page-content` instead. Filed upstream as **MRVDH/picnic-api#44**, with a fix in **MRVDH/picnic-api#45** — once that lands, these tools can switch to the library methods.

## Testing

`npm test` covers DE/NL/FR parsing, id/URL resolution (incl. the SSRF guard), and segment grouping. Also verified end-to-end against a live DE Picnic account: fetching catalog, personalized/scaled and user-defined recipes; browse/saved/own listing; save/unsave; and add/remove from cart.

Happy to adjust naming or split this up to match your preferences.


## Follow-up

Once [MRVDH/picnic-api#45](https://github.com/MRVDH/picnic-api/pull/45) is released, #43 (draft) switches these tools to the picnic-api library methods (`getRecipeDetailsPage` / `getCookbookPage`), removing the `sendRequest` workaround.
