### PR TITLE
refactor(recipes): use picnic-api recipe methods once #45 lands (follow-up to #42)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "picnic-api": "^4.0.0",
+        "undici": "^6.21.0",
         "zod": "^3.24.4",
         "zod-to-json-schema": "^3.25.1"
       },
@@ -71,16 +72,6 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^6.23.0"
-      }
-    },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
@@ -896,7 +887,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1435,6 +1425,16 @@
         "semantic-release": ">=24.1.0"
       }
     },
+    "node_modules/@semantic-release/github/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/@semantic-release/npm": {
       "version": "13.1.5",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
@@ -1648,7 +1648,6 @@
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1746,7 +1745,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2126,7 +2124,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3461,7 +3458,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3928,7 +3924,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4535,7 +4530,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4984,7 +4978,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5265,7 +5258,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7602,7 +7594,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8804,7 +8795,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9627,7 +9617,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9833,7 +9822,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9901,7 +9889,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10145,13 +10132,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
-      "dev": true,
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -10286,7 +10272,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10832,7 +10817,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11201,7 +11185,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
       "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "picnic-api": "^4.5.0",
+    "undici": "^6.21.0",
     "zod": "^3.24.4",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "picnic-api": "^4.0.0",
+    "picnic-api": "^4.5.0",
     "zod": "^3.24.4",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,12 @@ import { StdioServer } from "./transports/stdio.js"
 import { StreamableHttpServer } from "./transports/streamable-http.js"
 import { config } from "./config.js"
 import { initializePicnicClient } from "./utils/picnic-client.js"
+import { installFetchProxy } from "./utils/proxy.js"
 
 // Create and start the appropriate server
 async function runServer() {
+  // Route outbound fetch through HTTPS_PROXY when set, before any API call.
+  await installFetchProxy()
   await initializePicnicClient()
 
   if (config.ENABLE_HTTP_SERVER) {

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1,6 +1,13 @@
 import { z } from "zod"
 import { toolRegistry } from "./registry.js"
 import { getPicnicClient, initializePicnicClient, saveSession } from "../utils/picnic-client.js"
+import {
+  resolveRecipeId,
+  parseSellingGroupRecipe,
+  parseRecipeList,
+  buildRecipeSourceUrl,
+} from "../utils/recipe-parser.js"
+import { config } from "../config.js"
 
 /**
  * Picnic API tools optimized for LLM consumption
@@ -210,6 +217,237 @@ toolRegistry.register({
       size: args.size,
       image,
     }
+  },
+})
+
+// Recipe tools
+//
+// Picnic recipes are "selling groups". Recipe detail comes from
+// /pages/selling-group-details-page?selling_group_id=<id>, and the cookbook /
+// recipe overview from /pages/cookbook-page-content. These page routes are
+// called directly via sendRequest because the picnic-api recipe.* page methods
+// target outdated ids (recipe-details-page-root) that the API answers with 404.
+
+// Base URL for recipe/product image derivatives, derived from the API URL, e.g.
+// https://storefront-prod.de.picnicinternational.com/static/images
+function recipeImageBaseUrl(client: ReturnType<typeof getPicnicClient>): string {
+  return client.url.replace(/\/api\/.*$/, "/static/images")
+}
+
+async function fetchCookbookRecipes(client: ReturnType<typeof getPicnicClient>) {
+  const page = await client.sendRequest("GET", "/pages/cookbook-page-content", null, true)
+  return parseRecipeList(page, { imageBaseUrl: recipeImageBaseUrl(client) })
+}
+
+function paginateRecipes(all: ReturnType<typeof parseRecipeList>, offset: number, limit: number) {
+  const startIndex = offset || 0
+  const recipes = all.slice(startIndex, startIndex + limit).map((recipe) => ({
+    ...recipe,
+    sourceUrl: buildRecipeSourceUrl(config.PICNIC_COUNTRY_CODE, recipe.recipeId),
+  }))
+  return {
+    recipes,
+    pagination: {
+      offset: startIndex,
+      limit,
+      returned: recipes.length,
+      total: all.length,
+      hasMore: startIndex + limit < all.length,
+    },
+  }
+}
+
+// Get recipe tool
+const getRecipeInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe(
+      "A Picnic recipe URL (any format) or a 24-character hex recipe ID. " +
+        "Examples: 'https://picnic.app/de/go/abc123', " +
+        "'https://picnic.app/de/rezepte/0123456789abcdef01234567/example-recipe', " +
+        "'0123456789abcdef01234567'",
+    ),
+})
+
+toolRegistry.register({
+  name: "picnic_get_recipe",
+  description:
+    "Fetch a Picnic recipe by URL or recipe ID. Returns structured recipe data: name, " +
+    "description, ingredients, preparation steps, timing, servings, image URL, saved state, " +
+    "and the canonical source URL. Accepts short share links (picnic.app/de/go/xxx), full " +
+    "recipe URLs, or bare recipe IDs.",
+  inputSchema: getRecipeInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    const page = await client.sendRequest(
+      "GET",
+      `/pages/selling-group-details-page?selling_group_id=${encodeURIComponent(recipeId)}`,
+      null,
+      true,
+    )
+    const parsed = parseSellingGroupRecipe(page, { imageBaseUrl: recipeImageBaseUrl(client) })
+    const sourceUrl = buildRecipeSourceUrl(config.PICNIC_COUNTRY_CODE, recipeId)
+    return { recipeId, sourceUrl, ...parsed }
+  },
+})
+
+// Browse / saved recipes
+const recipeListInputSchema = z.object({
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .default(25)
+    .describe("Maximum number of recipes to return (1-100, default: 25)"),
+  offset: z
+    .number()
+    .min(0)
+    .default(0)
+    .describe("Number of recipes to skip for pagination (default: 0)"),
+})
+
+toolRegistry.register({
+  name: "picnic_browse_recipes",
+  description:
+    "Browse Picnic's recipe/cookbook overview to discover recipes. Returns a paginated list " +
+    "of recipes (id, name, image URL, cookbook section, source URL). Use the recipeId with " +
+    "picnic_get_recipe for full details.",
+  inputSchema: recipeListInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const all = await fetchCookbookRecipes(client)
+    return paginateRecipes(all, args.offset ?? 0, args.limit ?? 25)
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_get_saved_recipes",
+  description:
+    "List the recipes the user has saved/favourited in their Picnic cookbook (the " +
+    "'Gespeichert' tab), distinct from the public discovery feed. Returns id, name, image URL " +
+    "and source URL — useful for importing saved recipes elsewhere.",
+  inputSchema: recipeListInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const all = await fetchCookbookRecipes(client)
+    const saved = all.filter((recipe) => recipe.segments.includes("SAVED_RECIPES"))
+    return paginateRecipes(saved, args.offset ?? 0, args.limit ?? 25)
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_get_own_recipes",
+  description:
+    "List the user's own recipes (the cookbook 'Eigene Rezepte' tab — user-created recipes). " +
+    "Returns id, name, image URL and source URL.",
+  inputSchema: recipeListInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const all = await fetchCookbookRecipes(client)
+    const own = all.filter((recipe) => recipe.segments.includes("USER_DEFINED_RECIPES"))
+    return paginateRecipes(own, args.offset ?? 0, args.limit ?? 25)
+  },
+})
+
+// Save / unsave recipe
+const recipeRefInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe("A Picnic recipe URL (any format) or a 24-character hex recipe ID."),
+})
+
+toolRegistry.register({
+  name: "picnic_save_recipe",
+  description: "Save a recipe to the user's Picnic cookbook, by URL or recipe ID.",
+  inputSchema: recipeRefInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/recipe-saving",
+      { payload: { recipe_id: recipeId, saved_at: new Date().toISOString() } },
+      true,
+    )
+    return { message: "Recipe saved", recipeId }
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_unsave_recipe",
+  description: "Remove a recipe from the user's Picnic cookbook, by URL or recipe ID.",
+  inputSchema: recipeRefInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/recipe-saving",
+      { payload: { recipe_id: recipeId, saved_at: null } },
+      true,
+    )
+    return { message: "Recipe removed from cookbook", recipeId }
+  },
+})
+
+// Add a recipe's ingredients to the basket by assigning the selling group.
+const addRecipeToCartInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe("A Picnic recipe URL (any format) or a 24-character hex recipe ID."),
+  portions: z
+    .number()
+    .min(1)
+    .optional()
+    .describe("Number of portions to add (defaults to the recipe's default portions)."),
+})
+
+toolRegistry.register({
+  name: "picnic_add_recipe_to_cart",
+  description:
+    "Add a recipe's ingredients to the shopping cart by assigning the recipe (selling group) " +
+    "to the basket. Optionally set the number of portions.",
+  inputSchema: addRecipeToCartInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    const payload: { selling_group_id: string; portions?: number } = { selling_group_id: recipeId }
+    if (args.portions !== undefined) payload.portions = args.portions
+    await client.sendRequest("POST", "/pages/task/assign-selling-group-to-basket", { payload }, true)
+    return {
+      message: "Recipe added to cart",
+      recipeId,
+      ...(args.portions !== undefined && { portions: args.portions }),
+    }
+  },
+})
+
+// Remove a recipe's ingredients from the basket (inverse of add_recipe_to_cart).
+toolRegistry.register({
+  name: "picnic_remove_recipe_from_cart",
+  description:
+    "Remove a recipe (selling group) from the basket, undoing picnic_add_recipe_to_cart. " +
+    "Removes only that recipe's ingredients, leaving the rest of the cart untouched.",
+  inputSchema: recipeRefInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const recipeId = await resolveRecipeId(args.recipe_url_or_id)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/remove-selling-group-from-basket",
+      { payload: { selling_group_id: recipeId } },
+      true,
+    )
+    return { message: "Recipe removed from cart", recipeId }
   },
 })
 

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -222,11 +222,9 @@ toolRegistry.register({
 
 // Recipe tools
 //
-// Picnic recipes are "selling groups". Recipe detail comes from
-// /pages/selling-group-details-page?selling_group_id=<id>, and the cookbook /
-// recipe overview from /pages/cookbook-page-content. These page routes are
-// called directly via sendRequest because the picnic-api recipe.* page methods
-// target outdated ids (recipe-details-page-root) that the API answers with 404.
+// Picnic recipes are "selling groups". Recipe detail and the cookbook overview
+// are fetched through the picnic-api recipe domain (getRecipeDetailsPage /
+// getCookbookPage), which target the selling-group page routes.
 
 // Base URL for recipe/product image derivatives, derived from the API URL, e.g.
 // https://storefront-prod.de.picnicinternational.com/static/images
@@ -235,7 +233,7 @@ function recipeImageBaseUrl(client: ReturnType<typeof getPicnicClient>): string 
 }
 
 async function fetchCookbookRecipes(client: ReturnType<typeof getPicnicClient>) {
-  const page = await client.sendRequest("GET", "/pages/cookbook-page-content", null, true)
+  const page = await client.recipe.getCookbookPage()
   return parseRecipeList(page, { imageBaseUrl: recipeImageBaseUrl(client) })
 }
 
@@ -281,12 +279,7 @@ toolRegistry.register({
     await ensureClientInitialized()
     const client = getPicnicClient()
     const recipeId = await resolveRecipeId(args.recipe_url_or_id)
-    const page = await client.sendRequest(
-      "GET",
-      `/pages/selling-group-details-page?selling_group_id=${encodeURIComponent(recipeId)}`,
-      null,
-      true,
-    )
+    const page = await client.recipe.getRecipeDetailsPage(recipeId)
     const parsed = parseSellingGroupRecipe(page, { imageBaseUrl: recipeImageBaseUrl(client) })
     const sourceUrl = buildRecipeSourceUrl(config.PICNIC_COUNTRY_CODE, recipeId)
     return { recipeId, sourceUrl, ...parsed }

--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -442,13 +442,18 @@ export class StreamableHttpServer extends BaseTransportServer {
   public cleanupSession(sessionId: string): void {
     const transport = this.transports[sessionId]
     if (transport) {
-      transport.close()
+      // Remove the session from the map BEFORE closing. transport.close()
+      // synchronously fires transport.onclose (see createNewSession), which
+      // calls cleanupSession again; deleting first makes that re-entrant call a
+      // no-op and breaks what would otherwise be unbounded recursion ending in
+      // "RangeError: Maximum call stack size exceeded".
       delete this.transports[sessionId]
       const timeout = this.sessionTimeouts.get(sessionId)
       if (timeout) {
         clearTimeout(timeout)
         this.sessionTimeouts.delete(sessionId)
       }
+      transport.close()
       this.emit("session-ended", sessionId)
     }
   }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,30 @@
+// Optional outbound HTTP(S) proxy support.
+//
+// picnic-api uses Node's built-in fetch (undici), which ignores the HTTP_PROXY /
+// HTTPS_PROXY / NO_PROXY environment variables by default. When HTTPS_PROXY is
+// set, wrap globalThis.fetch with undici's EnvHttpProxyAgent so every request the
+// server makes (login, store API, recipes) is routed through the proxy and honours
+// NO_PROXY. This is useful behind egress-restricted networks where outbound traffic
+// must go through a forward proxy.
+//
+// Best-effort: if undici is unavailable the server continues with direct egress.
+// All logging goes to stderr — stdout is reserved for the stdio MCP transport.
+export async function installFetchProxy(): Promise<void> {
+  const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+  if (!proxyUrl) {
+    return
+  }
+
+  try {
+    const { fetch: undiciFetch, EnvHttpProxyAgent } = await import("undici")
+    const dispatcher = new EnvHttpProxyAgent()
+    globalThis.fetch = ((input: any, init?: any) =>
+      undiciFetch(input, { dispatcher, ...init })) as unknown as typeof fetch
+    console.error(`[mcp-picnic] outbound fetch routed via HTTPS_PROXY (${proxyUrl})`)
+  } catch (error) {
+    console.error(
+      "[mcp-picnic] HTTPS_PROXY is set but proxy setup failed; continuing with direct egress:",
+      error,
+    )
+  }
+}

--- a/src/utils/recipe-parser.ts
+++ b/src/utils/recipe-parser.ts
@@ -1,0 +1,677 @@
+/**
+ * Picnic recipe parsing.
+ *
+ * Picnic models recipes as "selling groups" — a recipe id IS a
+ * `selling_group_id`. The mobile API serves a recipe as a Fusion (PML) page at
+ * `GET /pages/selling-group-details-page?selling_group_id=<id>`, and the
+ * recipe/cookbook overview at `GET /pages/cookbook-page-content`. (The older
+ * `recipe-details-page-root` / `recipe_id` route returns 404.)
+ *
+ * Extraction is structured-first and therefore language-agnostic: name,
+ * description, hero image, portions and saved-state come from typed
+ * `selling_group_*_data` fields embedded in the page's SUSPENSE `parameters`.
+ * Ingredient lines and preparation steps are read from the rendered RICH_TEXT
+ * stream, delimited by the localized "Zutaten/Ingrediënten/Ingrédients"
+ * (ingredients) and "Zubereitung/Bereiding/Préparation/So wird's gemacht"
+ * (instructions) section headers, with steps anchored on the per-step
+ * "Schritt/Stap/Étape N" labels so unrelated product cards never leak in.
+ *
+ * Cookbook tiles carry a typed `segment_type` (SAVED_RECIPES,
+ * USER_DEFINED_RECIPES, NEW_RECIPES, …) used to group recipes by tab.
+ */
+
+/** Structured recipe data extracted from a Picnic selling-group recipe page. */
+export interface ParsedRecipe {
+  name: string | null
+  description: string | null
+  /** Short marketing tag, e.g. "Schnell und einfach". */
+  qualityCue: string | null
+  prepTime: string | null
+  /** e.g. "20 min" (total). */
+  totalTime: string | null
+  /** e.g. "2 Portionen". */
+  servings: string | null
+  imageUrl: string | null
+  /** Whether the recipe is saved to the user's cookbook (when known). */
+  isSaved: boolean | null
+  /** Recipe ingredient lines, e.g. ["Paprika 1 Stk.", "Basmatireis 100 g"]. */
+  ingredients: string[]
+  /** "Bring your own" pantry items (the "Eigene Zutaten" line). */
+  pantryIngredients: string[]
+  /** Equipment needed (the "Du benötigst" line), e.g. ["Bratpfanne"]. */
+  tools: string[]
+  /** Editorial tips (the "Tipp" section), not cooking steps. */
+  tips: string[]
+  /** Preparation step texts in order. */
+  instructions: string[]
+}
+
+/** {@link ParsedRecipe} plus the identifiers needed to ingest it elsewhere. */
+export interface PicnicRecipeResult extends ParsedRecipe {
+  /** 24-char hex recipe id (a selling_group_id). */
+  recipeId: string
+  /** Canonical picnic.app recipe URL. */
+  sourceUrl: string
+}
+
+/** A single recipe entry from the cookbook / recipe overview. */
+export interface RecipeListItem {
+  recipeId: string
+  name: string | null
+  imageUrl: string | null
+  /** Cookbook segments the recipe belongs to (e.g. ["SAVED_RECIPES"]). */
+  segments: string[]
+}
+
+// ── Recipe ID resolution ─────────────────────────────────────────────────────
+
+// A recipe id (selling_group_id) is 24 hex chars for catalog recipes and 32 for
+// the user's own (user-defined) recipes.
+const RECIPE_ID_RE = /^[a-f0-9]{24,32}$/
+// A recipe id as a URL path segment (DE rezepte / NL recepten / FR recettes).
+const RECIPE_ID_IN_URL_RE = /\/([a-f0-9]{24,32})(?:[/?#]|$)/
+// `selling_group_id=<id>` (or the legacy `recipe_id=<id>`) in a deep link.
+const ID_PARAM_RE = /(?:selling_group_id|recipe_id)=([a-f0-9]{24,32})/
+// Any recipe id reference, used when grouping cookbook tiles by segment.
+const ANY_ID_REF_RE = /(?:selling_group_id|recipe_id|recipeIds)=([a-f0-9]{24,32})/g
+
+const RECIPE_PATH_BY_COUNTRY: Record<string, string> = {
+  NL: "recepten",
+  DE: "rezepte",
+  FR: "recettes",
+}
+
+/**
+ * Build the canonical picnic.app recipe URL for a given country and recipe ID.
+ * Falls back to a neutral `recipes` path segment for unknown country codes.
+ */
+export function buildRecipeSourceUrl(countryCode: string, recipeId: string): string {
+  const segment = RECIPE_PATH_BY_COUNTRY[countryCode.toUpperCase()] ?? "recipes"
+  return `https://picnic.app/${countryCode.toLowerCase()}/${segment}/${recipeId}`
+}
+
+const ALLOWED_SHARE_HOSTS = new Set(["picnic.app"])
+
+function isAllowedShareHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return ALLOWED_SHARE_HOSTS.has(host) || host.endsWith(".picnic.app")
+}
+
+function assertAllowedShareUrl(raw: string): URL {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error(`Not a valid recipe URL: ${raw}`)
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`Refusing to resolve a non-https recipe URL: ${raw}`)
+  }
+  if (!isAllowedShareHost(url.hostname)) {
+    throw new Error(`Refusing to resolve a recipe URL outside picnic.app: ${url.hostname}`)
+  }
+  return url
+}
+
+/**
+ * Resolve a Picnic recipe URL (any format) or bare recipe id to a 24-char hex
+ * recipe id (a selling_group_id). The redirect-following request for short
+ * share links is restricted to `picnic.app` hosts over HTTPS (host re-checked
+ * after redirects) so it cannot be steered at arbitrary/internal hosts.
+ */
+export async function resolveRecipeId(input: string): Promise<string> {
+  const trimmed = input.trim()
+
+  if (RECIPE_ID_RE.test(trimmed)) return trimmed
+
+  const longMatch = trimmed.match(RECIPE_ID_IN_URL_RE)
+  if (longMatch) return longMatch[1]
+
+  const paramMatch = trimmed.match(ID_PARAM_RE)
+  if (paramMatch) return paramMatch[1]
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    const startUrl = assertAllowedShareUrl(trimmed)
+    const res = await fetch(startUrl.href, { method: "HEAD", redirect: "follow" })
+    const finalUrl = new URL(res.url || startUrl.href)
+    if (!isAllowedShareHost(finalUrl.hostname)) {
+      throw new Error(
+        `Recipe share link redirected off picnic.app to ${finalUrl.hostname}; refusing to follow`,
+      )
+    }
+    const resolvedMatch = finalUrl.href.match(RECIPE_ID_IN_URL_RE) ?? finalUrl.href.match(ID_PARAM_RE)
+    if (resolvedMatch) return resolvedMatch[1]
+  }
+
+  throw new Error(`Cannot extract a Picnic recipe id from: ${input}`)
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Object keys carrying actions/analytics/fallback UI rather than content. */
+const SKIP_KEYS = new Set([
+  "analytics",
+  "tracking_attributes",
+  "loadingConfig",
+  "errorConfig",
+  "placeholder",
+  "fallbackSource",
+  "presets",
+  "viewabilityListeners",
+])
+
+/** Strip Picnic colour markup, markdown action links and emphasis from a line. */
+function cleanLine(line: string): string {
+  return line
+    .replace(/#\(#[0-9a-fA-F]{6}\)/g, "")
+    .replace(/\[([^\]]+)\]\((?:action|app|https?):\/\/[^)]*\)/g, "$1")
+    .replace(/^\s*#{1,6}\s+/, "")
+    .replace(/^\s*[-*+]\s+/, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+// ── Localized section / label matchers ───────────────────────────────────────
+
+const INGREDIENT_HEADER_RE = /^(zutaten|ingredi[eë]nten|ingr[eé]dients?)$/i
+const INSTRUCTION_HEADER_RE =
+  /^(zubereitung(sschritte)?|anleitung|so wird.?s gemacht|bereiding(swijze)?|zo maak je het|pr[eé]paration|instructions?)$/i
+const STEP_LABEL_RE = /^(schritt|stap|[ée]tape|step)\s*\d+$/i
+const TIP_HEADER_RE = /^(tipps?|tips?|astuces?)$/i
+const TIME_RE = /\b\d+\s*min\b/i
+const TOTAL_TIME_RE = /\b(gesamt|insgesamt|total|totaal)\b/i
+const SERVINGS_RE = /\b(portion(en|s)?|porties|personen|personnes?)\b|\b\d+\s*pers\b/i
+// A clean servings *value* — a leading count plus a unit. Used to set the
+// servings field, so a nutrition header like "1 Portion des Originalrezepts
+// enthält ungefähr:" (which contains "Portion") is not mistaken for it.
+const SERVINGS_VALUE_RE = /^\d+\s*(portion(en|s)?|porties|personen|personnes?|pers\.?)$/i
+const NUMBER_ONLY_RE = /^\d+[.)]?$/
+const PANTRY_LINE_RE = /^(eigene zutaten|eigen recept|own ingredients|propres ingr[ée]dients?)\s*:\s*(.+)$/i
+const TOOLS_LINE_RE = /^(du ben[öo]tigst|je hebt nodig|you.?ll need|tu auras besoin)\s*:\s*(.+)$/i
+const BUTTON_WORDS = new Set([
+  "ansehen",
+  "hinzufügen",
+  "view",
+  "add",
+  "bekijken",
+  "toevoegen",
+  "voir",
+  "ajouter",
+])
+
+function splitMetaLine(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+// ── Structured (language-agnostic) extraction ────────────────────────────────
+
+interface StructuredRecipe {
+  name: string | null
+  description: string | null
+  qualityCue: string | null
+  imageId: string | null
+  imageNamespace: string | null
+  portions: number | null
+  isSaved: boolean | null
+}
+
+function collectStructured(page: unknown): StructuredRecipe {
+  const out: StructuredRecipe = {
+    name: null,
+    description: null,
+    qualityCue: null,
+    imageId: null,
+    imageNamespace: null,
+    portions: null,
+    isSaved: null,
+  }
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+
+    const title = n.selling_group_title_section_data
+    if (isRecord(title)) {
+      if (typeof title.name === "string") out.name = out.name ?? title.name
+      if (typeof title.description === "string")
+        out.description = out.description ?? title.description
+      if (typeof title.quality_cue === "string")
+        out.qualityCue = out.qualityCue ?? title.quality_cue
+    }
+
+    const header = n.selling_group_header_data
+    if (isRecord(header)) {
+      if (typeof header.is_saved === "boolean") out.isSaved = out.isSaved ?? header.is_saved
+      if (typeof header.sellable_name === "string") out.name = out.name ?? header.sellable_name
+      if (out.portions === null && typeof header.default_portions === "number")
+        out.portions = header.default_portions
+    }
+
+    const image = n.selling_group_image_data
+    if (isRecord(image)) {
+      const imgs = isRecord(image.images) ? image.images.images : undefined
+      if (Array.isArray(imgs)) {
+        const primary = imgs.find((x) => isRecord(x) && x.primary) ?? imgs[0]
+        if (isRecord(primary)) {
+          if (typeof primary.id === "string") out.imageId = out.imageId ?? primary.id
+          if (typeof primary.namespace === "string")
+            out.imageNamespace = out.imageNamespace ?? primary.namespace
+        }
+      }
+    }
+
+    if (typeof n.portions === "number") out.portions = n.portions
+
+    for (const v of Object.values(n)) visit(v)
+  }
+  visit(page)
+  return out
+}
+
+/** Collect cleaned RICH_TEXT lines in document order (skipping metadata keys). */
+function collectTextTokens(page: unknown): string[] {
+  const tokens: string[] = []
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.type === "RICH_TEXT" && typeof n.markdown === "string") {
+      for (const raw of n.markdown.split("\n")) {
+        const value = cleanLine(raw)
+        if (value) tokens.push(value)
+      }
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(page)
+  return tokens
+}
+
+function buildImageUrl(
+  imageId: string | null,
+  namespace: string | null,
+  imageBaseUrl?: string,
+): string | null {
+  if (!imageId || !imageBaseUrl) return null
+  const path = namespace && !imageId.includes("/") ? `${namespace}/${imageId}` : imageId
+  return `${imageBaseUrl.replace(/\/$/, "")}/${path}/large.png`
+}
+
+export interface ParseRecipeOptions {
+  /** Base for recipe image URLs, e.g. `https://storefront-prod.de…/static/images`. */
+  imageBaseUrl?: string
+}
+
+/**
+ * Parse a Picnic selling-group recipe page into structured recipe data. Returns
+ * an all-null/empty {@link ParsedRecipe} for unrecognized input rather than
+ * throwing. Robust to personalized/scaled recipes, whose pages interleave
+ * product cards, nutrition and allergen blocks with the recipe content.
+ */
+export function parseSellingGroupRecipe(page: unknown, opts: ParseRecipeOptions = {}): ParsedRecipe {
+  const struct = collectStructured(page)
+  const result: ParsedRecipe = {
+    name: struct.name,
+    description: struct.description,
+    qualityCue: struct.qualityCue,
+    prepTime: null,
+    totalTime: null,
+    servings: struct.portions !== null ? String(struct.portions) : null,
+    imageUrl: buildImageUrl(struct.imageId, struct.imageNamespace, opts.imageBaseUrl),
+    isSaved: struct.isSaved,
+    ingredients: [],
+    pantryIngredients: [],
+    tools: [],
+    tips: [],
+    instructions: [],
+  }
+
+  const tokens = collectTextTokens(page)
+
+  // Section anchors. The instruction header must come AFTER the ingredient
+  // header, so a stray product-card "Zubereitung" tab does not hijack it.
+  let ingredientStart = -1
+  let tipStart = -1
+  const stepIdx: number[] = []
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (ingredientStart < 0 && INGREDIENT_HEADER_RE.test(t)) ingredientStart = i
+    if (STEP_LABEL_RE.test(t)) stepIdx.push(i)
+    if (tipStart < 0 && TIP_HEADER_RE.test(t)) tipStart = i
+  }
+  let instructionStart = -1
+  for (let i = 0; i < tokens.length; i++) {
+    if (INSTRUCTION_HEADER_RE.test(tokens[i]) && (ingredientStart < 0 || i > ingredientStart)) {
+      instructionStart = i
+      break
+    }
+  }
+
+  // Timing: only in the meta region (before the instructions/steps), so a step
+  // that mentions a duration isn't mistaken for the recipe time.
+  const metaEnd =
+    instructionStart >= 0 ? instructionStart : stepIdx.length > 0 ? stepIdx[0] : tokens.length
+  for (let i = 0; i < metaEnd; i++) {
+    const t = tokens[i]
+    if (!TIME_RE.test(t)) continue
+    const next = tokens[i + 1] ?? ""
+    if (TOTAL_TIME_RE.test(t) || TOTAL_TIME_RE.test(next)) result.totalTime = result.totalTime ?? t
+    else result.prepTime = result.prepTime ?? t
+  }
+
+  // Servings: a clean "N Portionen" value anywhere (the structured portion
+  // count from collectStructured is the fallback).
+  for (const t of tokens) {
+    if (SERVINGS_VALUE_RE.test(t)) {
+      result.servings = t
+      break
+    }
+  }
+
+  // Ingredients: between the ingredient header and the instruction header,
+  // splitting out the "Eigene Zutaten" (pantry) and "Du benötigst" (tools) lines.
+  const ingEnd = instructionStart >= 0 ? instructionStart : tokens.length
+  if (ingredientStart >= 0) {
+    for (let i = ingredientStart + 1; i < ingEnd; i++) {
+      const t = tokens[i]
+      if (NUMBER_ONLY_RE.test(t) || t.length < 2 || BUTTON_WORDS.has(t.toLowerCase())) continue
+      const pantry = PANTRY_LINE_RE.exec(t)
+      if (pantry) {
+        result.pantryIngredients.push(...splitMetaLine(pantry[2]))
+        continue
+      }
+      const tools = TOOLS_LINE_RE.exec(t)
+      if (tools) {
+        result.tools.push(...splitMetaLine(tools[2]))
+        continue
+      }
+      if (SERVINGS_RE.test(t)) continue
+      result.ingredients.push(t)
+    }
+  }
+
+  // Instructions: anchored on the "Schritt N" labels (robust); otherwise fall
+  // back to the text after the instruction header, stopping at the tips block.
+  if (stepIdx.length > 0) {
+    const bounds = [...stepIdx, tipStart >= 0 ? tipStart : tokens.length, tokens.length]
+    for (const si of stepIdx) {
+      const next = Math.min(...bounds.filter((b) => b > si))
+      const body: string[] = []
+      for (let k = si + 1; k < next; k++) {
+        const t = tokens[k]
+        if (
+          STEP_LABEL_RE.test(t) ||
+          SERVINGS_RE.test(t) ||
+          NUMBER_ONLY_RE.test(t) ||
+          t.length < 2 ||
+          BUTTON_WORDS.has(t.toLowerCase())
+        )
+          continue
+        body.push(t)
+      }
+      if (body.length > 0) result.instructions.push(body.join(" "))
+    }
+  } else if (instructionStart >= 0) {
+    for (let k = instructionStart + 1; k < tokens.length; k++) {
+      const t = tokens[k]
+      if (TIP_HEADER_RE.test(t)) break
+      if (
+        SERVINGS_RE.test(t) ||
+        NUMBER_ONLY_RE.test(t) ||
+        STEP_LABEL_RE.test(t) ||
+        t.length < 2 ||
+        BUTTON_WORDS.has(t.toLowerCase())
+      )
+        continue
+      result.instructions.push(t)
+    }
+  }
+
+  // Tips: editorial notes after the "Tipp" header.
+  if (tipStart >= 0) {
+    for (let k = tipStart + 1; k < tokens.length; k++) {
+      const t = tokens[k]
+      if (t.length >= 2 && !BUTTON_WORDS.has(t.toLowerCase())) result.tips.push(t)
+    }
+  }
+
+  return result
+}
+
+// ── Cookbook list parsing (grouped by segment) ───────────────────────────────
+
+function findSegmentType(analytics: unknown): string | null {
+  const match = JSON.stringify(analytics).match(/"segment_type"\s*:\s*"([^"]+)"/)
+  return match ? match[1] : null
+}
+
+/**
+ * Map every recipe id in a cookbook page to the set of segment types it belongs
+ * to (SAVED_RECIPES, USER_DEFINED_RECIPES, NEW_RECIPES, …). Segment membership
+ * lives in the `segment_type` analytics on each tile/shelf, alongside the
+ * recipe's `selling_group_id` (single tiles) or `recipeIds` list (see-more).
+ */
+function collectSegmentsById(page: unknown): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>()
+  const add = (id: string, seg: string): void => {
+    const existing = map.get(id)
+    if (existing) existing.add(seg)
+    else map.set(id, new Set([seg]))
+  }
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.analytics !== undefined) {
+      const seg = findSegmentType(n.analytics)
+      if (seg) {
+        for (const m of JSON.stringify(n).matchAll(ANY_ID_REF_RE)) add(m[1], seg)
+        return
+      }
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (key === "analytics" || SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(page)
+  return map
+}
+
+function findLinkedRecipeId(node: unknown, depth: number): string | null {
+  if (depth > 8 || node === null || node === undefined) return null
+  if (typeof node === "string") {
+    const m = node.match(ID_PARAM_RE)
+    return m ? m[1] : null
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const id = findLinkedRecipeId(child, depth + 1)
+      if (id) return id
+    }
+    return null
+  }
+  if (!isRecord(node)) return null
+  for (const v of Object.values(node)) {
+    const id = findLinkedRecipeId(v, depth + 1)
+    if (id) return id
+  }
+  return null
+}
+
+/** Longest free-text RICH_TEXT line under a node (the recipe name, not a tag). */
+function firstRecipeNameIn(node: unknown): string | null {
+  const labels = new Set(["hinzufügen", "nicht alles vorrätig", "add", "toevoegen", "ajouter"])
+  let best: string | null = null
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.type === "RICH_TEXT" && typeof n.markdown === "string") {
+      for (const raw of n.markdown.split("\n")) {
+        const v = cleanLine(raw)
+        if (
+          v.length > 6 &&
+          v.length <= 90 &&
+          !labels.has(v.toLowerCase()) &&
+          !TIME_RE.test(v) &&
+          !SERVINGS_RE.test(v) &&
+          (best === null || v.length > best.length)
+        ) {
+          best = v
+        }
+      }
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (key === "onPress" || SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(node)
+  return best
+}
+
+function firstImageIn(node: unknown): { id: string; namespace: string | null } | null {
+  let found: { id: string; namespace: string | null } | null = null
+  const visit = (n: unknown): void => {
+    if (found) return
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.type === "IMAGE" && isRecord(n.source) && typeof n.source.id === "string") {
+      const ns = typeof n.source.namespace === "string" ? n.source.namespace : null
+      found = { id: n.source.id, namespace: ns }
+      return
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (key === "onPress" || SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(node)
+  return found
+}
+
+function hasRecipeTileAnalytics(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(hasRecipeTileAnalytics)
+  if (!isRecord(node)) return false
+  // `recipe_tile` is a catalog tile; `recipe_tile_mini` is a user-defined-recipe tile.
+  if (node.type === "recipe_tile" || node.type === "recipe_tile_mini") return true
+  return Object.values(node).some(hasRecipeTileAnalytics)
+}
+
+// Recipe names are also carried in `recipe` analytics contexts
+// ({recipe_id, recipe_name}) — the reliable source for user-defined recipes,
+// whose name is only present there (often inside an EXPRESSION string), not as
+// a rendered RICH_TEXT tile.
+const RECIPE_NAME_CONTEXT_RE =
+  /"recipe_id"\s*:\s*"([a-f0-9]{24,32})"[\s\S]{0,160}?"recipe_name"\s*:\s*"([^"]+)"/g
+
+function collectRecipeNames(page: unknown): Map<string, string> {
+  const map = new Map<string, string>()
+  const visit = (n: unknown): void => {
+    if (typeof n === "string") {
+      for (const m of n.matchAll(RECIPE_NAME_CONTEXT_RE)) if (!map.has(m[1])) map.set(m[1], m[2])
+      return
+    }
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (
+      typeof n.recipe_id === "string" &&
+      typeof n.recipe_name === "string" &&
+      !map.has(n.recipe_id)
+    ) {
+      map.set(n.recipe_id, n.recipe_name)
+    }
+    for (const v of Object.values(n)) visit(v)
+  }
+  visit(page)
+  return map
+}
+
+/** Collect rendered recipe tiles → name/image by recipe id. */
+function collectTileInfo(
+  page: unknown,
+  opts: ParseRecipeOptions,
+): Map<string, { name: string | null; imageUrl: string | null }> {
+  const info = new Map<string, { name: string | null; imageUrl: string | null }>()
+  const visit = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const x of n) visit(x)
+      return
+    }
+    if (!isRecord(n)) return
+    if (n.analytics !== undefined && hasRecipeTileAnalytics(n.analytics)) {
+      const recipeId = findLinkedRecipeId(n, 0)
+      if (recipeId && !info.has(recipeId)) {
+        const img = firstImageIn(n)
+        info.set(recipeId, {
+          name: firstRecipeNameIn(n),
+          imageUrl: img ? buildImageUrl(img.id, img.namespace, opts.imageBaseUrl) : null,
+        })
+      }
+      return
+    }
+    for (const [key, v] of Object.entries(n)) {
+      if (SKIP_KEYS.has(key)) continue
+      if (isRecord(v) || Array.isArray(v)) visit(v)
+    }
+  }
+  visit(page)
+  return info
+}
+
+/**
+ * Parse a cookbook / recipe-overview page into a flat list of recipe entries,
+ * each tagged with the cookbook segments it belongs to. Names and images come
+ * from the rendered tiles; recipes that exist only in a segment list (e.g.
+ * saved/own recipes not currently rendered) are still included, without a name.
+ */
+export function parseRecipeList(page: unknown, opts: ParseRecipeOptions = {}): RecipeListItem[] {
+  const segById = collectSegmentsById(page)
+  const tileInfo = collectTileInfo(page, opts)
+  const names = collectRecipeNames(page)
+  const out: RecipeListItem[] = []
+  const seen = new Set<string>()
+
+  for (const [id, segs] of segById) {
+    seen.add(id)
+    const info = tileInfo.get(id)
+    out.push({
+      recipeId: id,
+      name: info?.name ?? names.get(id) ?? null,
+      imageUrl: info?.imageUrl ?? null,
+      segments: [...segs],
+    })
+  }
+  for (const [id, info] of tileInfo) {
+    if (seen.has(id)) continue
+    out.push({ recipeId: id, name: info.name ?? names.get(id) ?? null, imageUrl: info.imageUrl, segments: [] })
+  }
+  return out
+}

--- a/test/unit/transports/streamable-http.test.ts
+++ b/test/unit/transports/streamable-http.test.ts
@@ -222,4 +222,34 @@ describe("StreamableHttpServer", () => {
     // We get a response (not 404), meaning the /mcp route exists
     expect(res.statusCode).not.toBe(404)
   })
+
+  it("cleanupSession does not recurse when transport.close() fires onclose", () => {
+    server = new StreamableHttpServer()
+    const sessionId = "regression-session"
+
+    // Faithful reproduction of the production scenario. createNewSession() wires
+    //   transport.onclose = () => cleanupSession(transport.sessionId)
+    // and the real SDK StreamableHTTPServerTransport.close() invokes onclose().
+    // Pre-fix, cleanupSession() called close() BEFORE removing the session from
+    // the map, so onclose -> cleanupSession -> close -> onclose recursed until
+    // the stack overflowed ("Maximum call stack size exceeded"). The module
+    // mock's close() does not fire onclose, which is why this was never caught.
+    const transport: any = { sessionId, onclose: undefined }
+    let closeCalls = 0
+    transport.close = () => {
+      closeCalls++
+      transport.onclose?.()
+    }
+    transport.onclose = () => {
+      if (transport.sessionId) server.cleanupSession(transport.sessionId)
+    }
+    // @ts-expect-error - private property access
+    server.transports[sessionId] = transport
+
+    expect(() => server.cleanupSession(sessionId)).not.toThrow()
+    expect(closeCalls).toBe(1)
+    // @ts-expect-error - private property access
+    expect(server.transports[sessionId]).toBeUndefined()
+    expect(server.getActiveSessions()).toHaveLength(0)
+  })
 })

--- a/test/unit/utils/recipe-parser.test.ts
+++ b/test/unit/utils/recipe-parser.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import {
+  resolveRecipeId,
+  parseSellingGroupRecipe,
+  parseRecipeList,
+  buildRecipeSourceUrl,
+} from "../../../src/utils/recipe-parser.js"
+
+const RECIPE_ID = "0123456789abcdef01234567"
+// User-defined recipe ids are 32 hex chars (catalog recipe ids are 24).
+const OWN_ID = "fedcba9876543210fedcba9876543210"
+const NEW_ID = "aaaaaaaaaaaaaaaaaaaaaaaa"
+const IMAGE_BASE = "https://cdn.example/static/images"
+
+function richText(markdown: string) {
+  return { type: "RICH_TEXT", markdown }
+}
+
+function suspense(parameters: Record<string, unknown>) {
+  return { type: "SUSPENSE", suspenseId: "s", pageConfig: { id: "selling-group-x", parameters } }
+}
+
+function detailPage(lines: string[], structured: Record<string, unknown>[]) {
+  return {
+    id: "selling-group-details-page-root",
+    body: {
+      type: "STATE_BOUNDARY",
+      child: {
+        type: "BLOCK",
+        children: [
+          ...structured.map(suspense),
+          { type: "PML", pml: { component: { type: "STACK", children: lines.map(richText) } } },
+        ],
+      },
+    },
+  }
+}
+
+describe("resolveRecipeId", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("returns a bare recipe id unchanged (24- or 32-char)", async () => {
+    await expect(resolveRecipeId(`  ${RECIPE_ID}  `)).resolves.toBe(RECIPE_ID)
+    await expect(resolveRecipeId(OWN_ID)).resolves.toBe(OWN_ID)
+    await expect(resolveRecipeId(`https://picnic.app/de/rezepte/${OWN_ID}/own`)).resolves.toBe(OWN_ID)
+  })
+
+  it("extracts the id from full recipe URLs across markets and deep links", async () => {
+    await expect(resolveRecipeId(`https://picnic.app/de/rezepte/${RECIPE_ID}/gyros`)).resolves.toBe(RECIPE_ID)
+    await expect(resolveRecipeId(`https://picnic.app/nl/recepten/${RECIPE_ID}/x`)).resolves.toBe(RECIPE_ID)
+    await expect(resolveRecipeId(`https://picnic.app/fr/recettes/${RECIPE_ID}?u=1`)).resolves.toBe(RECIPE_ID)
+    await expect(
+      resolveRecipeId(`app.picnic://store/page;id=selling-group-details-page,selling_group_id=${RECIPE_ID}`),
+    ).resolves.toBe(RECIPE_ID)
+  })
+
+  it("follows a short share link redirect on picnic.app", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ url: `https://picnic.app/de/rezepte/${RECIPE_ID}?path=selling_group_id%3D${RECIPE_ID}` }),
+    )
+    await expect(resolveRecipeId("https://picnic.app/de/go/abc123")).resolves.toBe(RECIPE_ID)
+  })
+
+  it("refuses to request a non-picnic host (SSRF guard)", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(resolveRecipeId("https://10.0.0.5/")).rejects.toThrow(/picnic\.app/)
+    await expect(resolveRecipeId("http://169.254.169.254/")).rejects.toThrow()
+    await expect(resolveRecipeId("http://picnic.app/de/go/x")).rejects.toThrow(/non-https/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("refuses when a picnic.app link redirects off-domain", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ url: "https://evil.example/internal" }))
+    await expect(resolveRecipeId("https://picnic.app/de/go/xxx")).rejects.toThrow(/redirected off/)
+  })
+
+  it("throws when no id can be extracted", async () => {
+    await expect(resolveRecipeId("not-a-recipe")).rejects.toThrow(/Cannot extract/)
+  })
+})
+
+describe("parseSellingGroupRecipe", () => {
+  it("parses a recipe robustly despite a stray product-card 'Zubereitung'", () => {
+    const page = detailPage(
+      [
+        "Gyros-Reispfanne mit Feta",
+        "One-Pot-Favorit",
+        "20 min",
+        "Gesamt",
+        "Zubereitung", // stray product-card tab — must NOT hijack instructions
+        "Paprika Mix",
+        "2.24",
+        "(1 Stk. benötigt)",
+        "1 Portion des Originalrezepts enthält ungefähr:", // nutrition header — must NOT become servings
+        "Zutaten",
+        "**Paprika** 1 Stk.",
+        "**Basmatireis** 100 g",
+        "**Gyros** 250 g",
+        "**Eigene Zutaten:** 0.5 Stk. Knoblauch, Olivenöl, Salz und Pfeffer",
+        "**Du benötigst:** Bratpfanne",
+        "So wird's gemacht",
+        "2 Portionen",
+        "Schritt 1",
+        "Paprika waschen und würfeln.",
+        "Schritt 2",
+        "Gyros anbraten. [Zurück zum Original](action://open-undo)",
+        "Tipp",
+        "Dazu passt ein Salat.",
+      ],
+      [
+        {
+          selling_group_title_section_data: {
+            name: "Gyros-Reispfanne mit Feta",
+            description: "Eine schnelle One-Pot-Reispfanne.",
+            quality_cue: "One-Pot-Favorit",
+          },
+        },
+        { selling_group_image_data: { images: { images: [{ id: "img1", namespace: "recipes", primary: true }] } } },
+        { selling_group_header_data: { is_saved: true, default_portions: 4 } },
+        { portions: 2 },
+      ],
+    )
+
+    const r = parseSellingGroupRecipe(page, { imageBaseUrl: IMAGE_BASE })
+    expect(r.name).toBe("Gyros-Reispfanne mit Feta")
+    expect(r.qualityCue).toBe("One-Pot-Favorit")
+    expect(r.totalTime).toBe("20 min")
+    expect(r.servings).toBe("2 Portionen")
+    expect(r.isSaved).toBe(true)
+    expect(r.imageUrl).toBe(`${IMAGE_BASE}/recipes/img1/large.png`)
+    expect(r.ingredients).toEqual(["Paprika 1 Stk.", "Basmatireis 100 g", "Gyros 250 g"])
+    expect(r.pantryIngredients).toEqual(["0.5 Stk. Knoblauch", "Olivenöl", "Salz und Pfeffer"])
+    expect(r.tools).toEqual(["Bratpfanne"])
+    expect(r.instructions).toEqual([
+      "Paprika waschen und würfeln.",
+      "Gyros anbraten. Zurück zum Original", // action link stripped to its label
+    ])
+    expect(r.tips).toEqual(["Dazu passt ein Salat."])
+  })
+
+  it("parses Dutch and French recipes via localized headers and step labels", () => {
+    const nl = detailPage(
+      ["Ingrediënten", "**Rijst** 200 g", "Bereiding", "4 porties", "Stap 1", "Kook de rijst."],
+      [{ selling_group_title_section_data: { name: "Rijstschotel", description: null } }],
+    )
+    const rnl = parseSellingGroupRecipe(nl)
+    expect(rnl.name).toBe("Rijstschotel")
+    expect(rnl.servings).toBe("4 porties")
+    expect(rnl.ingredients).toEqual(["Rijst 200 g"])
+    expect(rnl.instructions).toEqual(["Kook de rijst."])
+
+    const fr = detailPage(
+      ["Ingrédients", "**Riz** 200 g", "Préparation", "4 personnes", "Étape 1", "Cuire le riz."],
+      [{ selling_group_title_section_data: { name: "Poêlée de riz", description: null } }],
+    )
+    const rfr = parseSellingGroupRecipe(fr)
+    expect(rfr.instructions).toEqual(["Cuire le riz."])
+    expect(rfr.ingredients).toEqual(["Riz 200 g"])
+  })
+
+  it("returns metadata for a recipe with no rendered ingredient/step sections (user-defined recipe)", () => {
+    // User-defined recipes carry structured metadata but no Zutaten/Schritt
+    // RICH_TEXT sections — name must be set and ingredients/steps stay empty.
+    const page = detailPage(
+      ["My Recipe"],
+      [
+        { selling_group_title_section_data: { name: "My Recipe", description: null } },
+        { selling_group_header_data: { is_saved: false, default_portions: 4 } },
+      ],
+    )
+    const r = parseSellingGroupRecipe(page)
+    expect(r.name).toBe("My Recipe")
+    expect(r.isSaved).toBe(false)
+    expect(r.ingredients).toEqual([])
+    expect(r.instructions).toEqual([])
+    expect(r.pantryIngredients).toEqual([])
+  })
+
+  it("returns an empty result for unrecognized input without throwing", () => {
+    const empty = {
+      name: null,
+      description: null,
+      qualityCue: null,
+      prepTime: null,
+      totalTime: null,
+      servings: null,
+      imageUrl: null,
+      isSaved: null,
+      ingredients: [],
+      pantryIngredients: [],
+      tools: [],
+      tips: [],
+      instructions: [],
+    }
+    expect(parseSellingGroupRecipe(null)).toEqual(empty)
+    expect(parseSellingGroupRecipe({})).toEqual(empty)
+  })
+})
+
+describe("parseRecipeList", () => {
+  function cookbookTile(id: string, name: string, segmentType: string, imageId: string) {
+    return {
+      type: "PML",
+      id: `tile-${id}`,
+      analytics: {
+        contexts: [
+          { data: { type: "recipe_tile", template_id: "cookbook-recipe-tile" }, schema: "iglu:x/pml_component/1" },
+          { data: { segment_name: segmentType, segment_type: segmentType }, schema: "iglu:x/segment/1" },
+        ],
+      },
+      pml: {
+        component: {
+          type: "TOUCHABLE",
+          onPress: {
+            type: "EXPRESSION",
+            expression: `onPMLAction({ actionType: "OPEN", target: "app.picnic://store/page;id=selling-group-details-page,selling_group_id=${id}" })`,
+          },
+          child: {
+            type: "STACK",
+            children: [{ type: "IMAGE", source: { id: imageId, namespace: "recipes" } }, richText(name)],
+          },
+        },
+      },
+    }
+  }
+
+  // A user-defined-recipe tile: recipe_tile_mini, name only in the analytics
+  // `recipe` context (inside an EXPRESSION), no rendered RICH_TEXT name.
+  function udrTile(id: string, name: string) {
+    return {
+      type: "CONTAINER",
+      analytics: {
+        contexts: [
+          { data: { type: "recipe_tile_mini", template_id: "core-uds-recipe-tile" }, schema: "iglu:x/pml_component/1" },
+          { data: { recipe_id: id, recipe_image_type: "GALLERY", recipe_name: name }, schema: "iglu:x/recipe/1" },
+          { data: { segment_name: "Eigene Rezepte", segment_type: "USER_DEFINED_RECIPES" }, schema: "iglu:x/segment/1" },
+        ],
+      },
+      child: {
+        type: "TOUCHABLE",
+        onPress: {
+          type: "EXPRESSION",
+          expression: `onPMLAction({ actionType: "OPEN", target: "app.picnic://store/page;id=selling-group-details-page,selling_group_id=${id}" })`,
+        },
+      },
+    }
+  }
+
+  function cookbook(children: unknown[]) {
+    return { id: "cookbook", body: { type: "STATE_BOUNDARY", child: { type: "BLOCK", children } } }
+  }
+
+  it("groups recipes by segment, with names/images from tiles", () => {
+    const page = cookbook([
+      cookbookTile(RECIPE_ID, "Gyros-Reispfanne mit Feta", "SAVED_RECIPES", "abc"),
+      udrTile(OWN_ID, "My Recipe"),
+      cookbookTile(NEW_ID, "Neues Rezept", "NEW_RECIPES", "ghi"),
+    ])
+    const list = parseRecipeList(page, { imageBaseUrl: IMAGE_BASE })
+    expect(list).toHaveLength(3)
+
+    const saved = list.filter((r) => r.segments.includes("SAVED_RECIPES"))
+    expect(saved).toEqual([
+      {
+        recipeId: RECIPE_ID,
+        name: "Gyros-Reispfanne mit Feta",
+        imageUrl: `${IMAGE_BASE}/recipes/abc/large.png`,
+        segments: ["SAVED_RECIPES"],
+      },
+    ])
+
+    const own = list.filter((r) => r.segments.includes("USER_DEFINED_RECIPES"))
+    expect(own.map((r) => [r.recipeId, r.name])).toEqual([[OWN_ID, "My Recipe"]])
+  })
+
+  it("returns an empty list for a page with no recipe tiles", () => {
+    expect(parseRecipeList(cookbook([richText("Hello")]))).toEqual([])
+  })
+})
+
+describe("buildRecipeSourceUrl", () => {
+  it("uses the localized path segment per country, with a neutral fallback", () => {
+    expect(buildRecipeSourceUrl("DE", RECIPE_ID)).toBe(`https://picnic.app/de/rezepte/${RECIPE_ID}`)
+    expect(buildRecipeSourceUrl("NL", RECIPE_ID)).toBe(`https://picnic.app/nl/recepten/${RECIPE_ID}`)
+    expect(buildRecipeSourceUrl("FR", RECIPE_ID)).toBe(`https://picnic.app/fr/recettes/${RECIPE_ID}`)
+    expect(buildRecipeSourceUrl("XX", RECIPE_ID)).toBe(`https://picnic.app/xx/recipes/${RECIPE_ID}`)
+  })
+})


### PR DESCRIPTION
> **Draft — do not merge yet.** Follow-up to #42 (the recipe tools).

## What

Once [MRVDH/picnic-api#45](https://github.com/MRVDH/picnic-api/pull/45) is merged and released, the raw-`sendRequest` workaround in #42 is no longer needed. This switches:

- `picnic_get_recipe` → `client.recipe.getRecipeDetailsPage(recipeId)`
- the cookbook fetch (browse / saved / own) → `client.recipe.getCookbookPage()`

and bumps the `picnic-api` dependency to a version that includes that fix.

## Blocked on

1. #42 (the recipe tools) merging first — this PR is stacked on that branch, so the diff here currently includes #42's changes; it reduces to just the `sendRequest`→library switch once #42 lands.
2. [MRVDH/picnic-api#45](https://github.com/MRVDH/picnic-api/pull/45) being merged **and published** to npm. The `picnic-api` version bump here (`^4.5.0`) is a placeholder — it must be pinned to the actual release that contains `getCookbookPage` and the fixed `getRecipeDetailsPage`.

Until both land, CI will fail (the library methods don't exist in the current `picnic-api`), which is expected.
