### PR TITLE
feat: optional HTTPS_PROXY support for outbound requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "picnic-api": "^4.5.0",
+        "undici": "^6.21.0",
         "zod": "^3.24.4",
         "zod-to-json-schema": "^3.25.1"
       },
@@ -71,16 +72,6 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^6.23.0"
-      }
-    },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
@@ -1432,6 +1423,16 @@
       },
       "peerDependencies": {
         "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -10131,13 +10132,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
-      "dev": true,
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "picnic-api": "^4.5.0",
+    "undici": "^6.21.0",
     "zod": "^3.24.4",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,12 @@ import { StdioServer } from "./transports/stdio.js"
 import { StreamableHttpServer } from "./transports/streamable-http.js"
 import { config } from "./config.js"
 import { initializePicnicClient } from "./utils/picnic-client.js"
+import { installFetchProxy } from "./utils/proxy.js"
 
 // Create and start the appropriate server
 async function runServer() {
+  // Route outbound fetch through HTTP_PROXY / HTTPS_PROXY when set, before any API call.
+  await installFetchProxy()
   await initializePicnicClient()
 
   if (config.ENABLE_HTTP_SERVER) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,36 @@
+// Optional outbound HTTP(S) proxy support.
+//
+// picnic-api uses Node's built-in fetch (undici), which ignores the HTTP_PROXY /
+// HTTPS_PROXY / NO_PROXY environment variables by default. When HTTP_PROXY or
+// HTTPS_PROXY is set, wrap globalThis.fetch with undici's EnvHttpProxyAgent so
+// every request the server makes (login, store API, recipes) is routed through
+// the proxy and honours NO_PROXY. This is useful behind egress-restricted networks
+// where outbound traffic must go through a forward proxy.
+//
+// Best-effort: if undici is unavailable the server continues with direct egress.
+// All logging goes to stderr — stdout is reserved for the stdio MCP transport.
+export async function installFetchProxy(): Promise<void> {
+  const proxyUrl =
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy
+  if (!proxyUrl) {
+    return
+  }
+
+  try {
+    const { fetch: undiciFetch, EnvHttpProxyAgent } = await import("undici")
+    const dispatcher = new EnvHttpProxyAgent()
+    globalThis.fetch = ((
+      input: Parameters<typeof undiciFetch>[0],
+      init?: Parameters<typeof undiciFetch>[1],
+    ) => undiciFetch(input, { ...init, dispatcher })) as unknown as typeof fetch
+    console.error(`[mcp-picnic] outbound fetch routed through proxy (${proxyUrl})`)
+  } catch (error) {
+    console.error(
+      "[mcp-picnic] proxy env var is set but proxy setup failed; continuing with direct egress:",
+      error,
+    )
+  }
+}


### PR DESCRIPTION
## Problem

`mcp-picnic` makes all of its outbound HTTPS calls — authentication, the Picnic store API, and the recipe endpoints — through the `picnic-api` library, which relies on Node's built-in `fetch` (powered by undici).

Node's global `fetch` does **not** honour the conventional `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` environment variables. So in any environment where outbound traffic must traverse a forward/egress proxy — corporate networks, locked-down containers, CI runners, or hosts without direct internet access — the server cannot reach Picnic, and there is currently no way to point it at a proxy.

## Intention

Support the de-facto-standard proxy environment variables so the server runs unchanged behind a forward proxy. The feature is:

- **Opt-in** — completely inert unless `HTTP_PROXY` / `HTTPS_PROXY` (or their lowercase forms) is set.
- **Zero-impact when unset** — no behavioural change and no new runtime cost for existing users.
- **Standards-based** — honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`, including `NO_PROXY` bypass.

## What this adds

- A small `src/utils/proxy.ts` exporting `installFetchProxy()`, called once at startup in `runServer()`, before any request is made.
- When a proxy is configured, it wraps `globalThis.fetch` to dispatch through undici's `EnvHttpProxyAgent`, which reads the proxy env vars. Every subsequent `fetch` — including everything `picnic-api` does internally — is then routed through the proxy.
- Best-effort and non-fatal: if undici cannot be loaded, the server logs a notice and continues with direct egress.
- All logging goes to **stderr**, so it never interferes with the stdio MCP transport (which owns stdout).

## Implementation note — why wrap `fetch` instead of `setGlobalDispatcher()`

Node's global `fetch` uses Node's *built-in* undici instance. Calling `setGlobalDispatcher()` from the installed `undici` package does not reliably affect that built-in instance — depending on the Node version they can be different module instances — so the proxy silently has no effect. Replacing `globalThis.fetch` with undici's own `fetch` bound to an explicit `EnvHttpProxyAgent` dispatcher works reliably across Node versions.

## Usage

```sh
HTTPS_PROXY=http://proxy.example:3128 NO_PROXY=localhost npx mcp-picnic
```

## Testing / impact

- `undici` is added as a dependency for the `EnvHttpProxyAgent` API (it already ships inside Node, but the public agent class must be imported from the package).
- The added module type-checks and the build passes.
- Verified manually: with `HTTPS_PROXY` unset, behaviour is unchanged; with it set, outbound `fetch` traffic is observed transiting the proxy, and `NO_PROXY` entries bypass it.