### PR TITLE
fix: prevent infinite recursion in cleanupSession on transport close

### DIFF
--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -442,13 +442,18 @@ export class StreamableHttpServer extends BaseTransportServer {
   public cleanupSession(sessionId: string): void {
     const transport = this.transports[sessionId]
     if (transport) {
-      transport.close()
+      // Remove the session from the map BEFORE closing. transport.close()
+      // synchronously fires transport.onclose (see createNewSession), which
+      // calls cleanupSession again; deleting first makes that re-entrant call a
+      // no-op and breaks what would otherwise be unbounded recursion ending in
+      // "RangeError: Maximum call stack size exceeded".
       delete this.transports[sessionId]
       const timeout = this.sessionTimeouts.get(sessionId)
       if (timeout) {
         clearTimeout(timeout)
         this.sessionTimeouts.delete(sessionId)
       }
+      transport.close()
       this.emit("session-ended", sessionId)
     }
   }

--- a/test/unit/transports/streamable-http.test.ts
+++ b/test/unit/transports/streamable-http.test.ts
@@ -222,4 +222,34 @@ describe("StreamableHttpServer", () => {
     // We get a response (not 404), meaning the /mcp route exists
     expect(res.statusCode).not.toBe(404)
   })
+
+  it("cleanupSession does not recurse when transport.close() fires onclose", () => {
+    server = new StreamableHttpServer()
+    const sessionId = "regression-session"
+
+    // Faithful reproduction of the production scenario. createNewSession() wires
+    //   transport.onclose = () => cleanupSession(transport.sessionId)
+    // and the real SDK StreamableHTTPServerTransport.close() invokes onclose().
+    // Pre-fix, cleanupSession() called close() BEFORE removing the session from
+    // the map, so onclose -> cleanupSession -> close -> onclose recursed until
+    // the stack overflowed ("Maximum call stack size exceeded"). The module
+    // mock's close() does not fire onclose, which is why this was never caught.
+    const transport: any = { sessionId, onclose: undefined }
+    let closeCalls = 0
+    transport.close = () => {
+      closeCalls++
+      transport.onclose?.()
+    }
+    transport.onclose = () => {
+      if (transport.sessionId) server.cleanupSession(transport.sessionId)
+    }
+    // @ts-expect-error - private property access
+    server.transports[sessionId] = transport
+
+    expect(() => server.cleanupSession(sessionId)).not.toThrow()
+    expect(closeCalls).toBe(1)
+    // @ts-expect-error - private property access
+    expect(server.transports[sessionId]).toBeUndefined()
+    expect(server.getActiveSessions()).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## Problem

`StreamableHttpServer.cleanupSession()` crashes the process with `RangeError: Maximum call stack size exceeded` on normal session teardown (client disconnect, `DELETE /mcp`, or the idle session timeout).

## Root cause

In `src/transports/streamable-http.ts`, `cleanupSession()` calls `transport.close()` **before** removing the session from the `transports` map:

```ts
public cleanupSession(sessionId: string): void {
  const transport = this.transports[sessionId]
  if (transport) {
    transport.close()                  // (1) synchronously fires onclose…
    delete this.transports[sessionId]  // (2) …but the delete happens only after
    ...
  }
}
```

`StreamableHTTPServerTransport.close()` synchronously invokes `transport.onclose`, and `createNewSession()` wires it to call `cleanupSession()` again:

```ts
transport.onclose = () => {
  if (transport.sessionId) {
    this.cleanupSession(transport.sessionId)
  }
}
```

Because the session is still in the map when `close()` re-enters `cleanupSession()`, it closes again → `onclose` → `cleanupSession` → `close` … unbounded recursion → stack overflow → the Node process exits.

## Fix

Remove the session from the map (and clear its timeout) **before** calling `transport.close()`, so the re-entrant `cleanupSession()` finds nothing and is a no-op.

## Test

Added a regression test in `test/unit/transports/streamable-http.test.ts` that reproduces the overflow (and fails without the fix). The existing tests missed this because the module-level transport mock's `close()` never invokes `onclose`, unlike the real SDK transport — the test makes `close()` faithful to that contract.

Full suite passes (`npm test`) and the bundle builds (`npm run build`).