### PR TITLE
feat(recipes): add meal planning helpers

### DIFF
--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -7,6 +7,11 @@ import {
   parseRecipeList,
   buildRecipeSourceUrl,
 } from "../utils/recipe-parser.js"
+import {
+  buildShoppingList,
+  findMealCombinations,
+  parseRecipeIngredients,
+} from "../utils/recipe-meal-planning.js"
 import { config } from "../config.js"
 
 /**
@@ -421,7 +426,12 @@ toolRegistry.register({
     const recipeId = await resolveRecipeId(args.recipe_url_or_id)
     const payload: { selling_group_id: string; portions?: number } = { selling_group_id: recipeId }
     if (args.portions !== undefined) payload.portions = args.portions
-    await client.sendRequest("POST", "/pages/task/assign-selling-group-to-basket", { payload }, true)
+    await client.sendRequest(
+      "POST",
+      "/pages/task/assign-selling-group-to-basket",
+      { payload },
+      true,
+    )
     return {
       message: "Recipe added to cart",
       recipeId,
@@ -449,6 +459,128 @@ toolRegistry.register({
     )
     return { message: "Recipe removed from cart", recipeId }
   },
+})
+
+// Recipe meal-planning tools
+const recipeIngredientsInputSchema = z.object({
+  recipe_url_or_id: z
+    .string()
+    .describe("A Picnic recipe URL (any format) or a 24- or 32-character hex recipe ID."),
+})
+
+async function fetchRecipeIngredientsByRef(
+  client: ReturnType<typeof getPicnicClient>,
+  recipeUrlOrId: string,
+) {
+  const recipeId = await resolveRecipeId(recipeUrlOrId)
+  const page = await client.sendRequest(
+    "GET",
+    `/pages/selling-group-details-page?selling_group_id=${encodeURIComponent(recipeId)}`,
+    null,
+    true,
+  )
+  const parsed = parseRecipeIngredients(page)
+  if (!parsed) throw new Error(`Could not find recipe ingredient data for ${recipeId}`)
+  return parsed
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+toolRegistry.register({
+  name: "picnic_get_recipe_ingredients",
+  description:
+    "Fetch structured Picnic recipe ingredients by recipe URL or ID. Returns selling-unit IDs, " +
+    "quantities, pantry flags, package display text, and prices for meal planning.",
+  inputSchema: recipeIngredientsInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    return fetchRecipeIngredientsByRef(getPicnicClient(), args.recipe_url_or_id)
+  },
+})
+
+toolRegistry.register({
+  name: "picnic_get_multiple_recipe_ingredients",
+  description:
+    "Fetch structured ingredient lists for multiple Picnic recipes. Returns successful recipes " +
+    "and per-input errors so one unavailable recipe does not discard the whole batch.",
+  inputSchema: z.object({
+    recipe_urls_or_ids: z
+      .array(z.string())
+      .min(1)
+      .max(20)
+      .describe("Picnic recipe URLs or 24-/32-character recipe IDs, up to 20."),
+  }),
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const results = await Promise.allSettled(
+      args.recipe_urls_or_ids.map((input) => fetchRecipeIngredientsByRef(client, input)),
+    )
+
+    return {
+      recipes: results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
+      errors: results.flatMap((result, index) =>
+        result.status === "rejected"
+          ? [{ input: args.recipe_urls_or_ids[index], error: getErrorMessage(result.reason) }]
+          : [],
+      ),
+    }
+  },
+})
+
+const recipeIngredientSchema = z.object({
+  ingredientId: z.string(),
+  sellingUnitId: z.string(),
+  name: z.string(),
+  packageInfo: z.string(),
+  priceCents: z.number().nullable(),
+  quantity: z.number(),
+  isPantryItem: z.boolean(),
+})
+
+const structuredRecipeIngredientsSchema = z.object({
+  recipeId: z.string(),
+  recipeName: z.string(),
+  portions: z.number(),
+  ingredients: z.array(recipeIngredientSchema),
+})
+
+toolRegistry.register({
+  name: "picnic_build_shopping_list",
+  description:
+    "Consolidate structured recipe ingredients into a shopping list. Skips pantry items, " +
+    "deduplicates products per recipe, and totals priceCents times quantity.",
+  inputSchema: z.object({
+    recipes: z.array(structuredRecipeIngredientsSchema).min(1).max(20),
+  }),
+  handler: async (args) => buildShoppingList(args.recipes),
+})
+
+toolRegistry.register({
+  name: "picnic_find_meal_combinations",
+  description:
+    "Rank combinations of structured Picnic recipes by shared non-pantry ingredients, " +
+    "using the same conservative cost calculation as picnic_build_shopping_list.",
+  inputSchema: z.object({
+    recipes: z.array(structuredRecipeIngredientsSchema).min(2).max(50),
+    count: z.number().int().min(2).describe("Number of recipes per combination."),
+    topK: z
+      .number()
+      .int()
+      .min(1)
+      .max(20)
+      .default(5)
+      .describe("Maximum number of combinations to return."),
+    maxTotalBudgetCents: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Exclude combinations whose conservative shopping-list cost exceeds this."),
+  }),
+  handler: async (args) => findMealCombinations(args),
 })
 
 // Get shopping cart tool
@@ -853,4 +985,3 @@ toolRegistry.register({
     }
   },
 })
-

--- a/src/utils/recipe-meal-planning.ts
+++ b/src/utils/recipe-meal-planning.ts
@@ -70,8 +70,8 @@ interface RecipeContext {
   sellingUnits: SellingUnitContext[]
 }
 
-interface IngredientTile {
-  ingredientId: string
+interface ProductTile {
+  sellingUnitId: string
   name: string
   packageInfo: string
   priceCents: number | null
@@ -136,10 +136,7 @@ function isDisplayNoise(value: string): boolean {
   )
 }
 
-function extractProductDisplay(
-  ingredientId: string,
-  node: Record<string, unknown>,
-): IngredientTile {
+function extractProductDisplay(sellingUnitId: string, node: Record<string, unknown>): ProductTile {
   const markdowns: string[] = []
   collectMarkdowns(node.pml ?? node, markdowns)
 
@@ -153,15 +150,15 @@ function extractProductDisplay(
   )
 
   return {
-    ingredientId,
+    sellingUnitId,
     name: nameIndex >= 0 ? markdowns[nameIndex] : "",
     packageInfo: packageIndex >= 0 ? markdowns[packageIndex] : "",
     priceCents,
   }
 }
 
-function collectIngredientTiles(pageData: unknown): Map<string, IngredientTile> {
-  const tiles = new Map<string, IngredientTile>()
+function collectProductTiles(pageData: unknown): Map<string, ProductTile> {
+  const tiles = new Map<string, ProductTile>()
 
   function walk(value: unknown, depth: number): void {
     if (depth > 80 || !isRecord(value)) {
@@ -178,9 +175,9 @@ function collectIngredientTiles(pageData: unknown): Map<string, IngredientTile> 
     for (const context of contexts) {
       if (!isRecord(context) || !isRecord(context.data)) continue
       if (typeof context.data.product_id !== "string") continue
-      const ingredientId = context.data.product_id
-      if (!tiles.has(ingredientId)) {
-        tiles.set(ingredientId, extractProductDisplay(ingredientId, value))
+      const sellingUnitId = context.data.product_id
+      if (!tiles.has(sellingUnitId)) {
+        tiles.set(sellingUnitId, extractProductDisplay(sellingUnitId, value))
       }
     }
 
@@ -273,13 +270,13 @@ export function parseRecipeIngredients(pageData: unknown): StructuredRecipeIngre
   const context = extractRecipeContext(pageData)
   if (!context) return null
 
-  const tiles = collectIngredientTiles(pageData)
+  const tiles = collectProductTiles(pageData)
   return {
     recipeId: context.recipeId,
     recipeName: context.recipeName,
     portions: context.portions,
     ingredients: context.sellingUnits.map((unit) => {
-      const tile = tiles.get(unit.ingredientId)
+      const tile = tiles.get(unit.sellingUnitId)
       return {
         ingredientId: unit.ingredientId,
         sellingUnitId: unit.sellingUnitId,

--- a/src/utils/recipe-meal-planning.ts
+++ b/src/utils/recipe-meal-planning.ts
@@ -1,0 +1,474 @@
+export interface RecipeIngredient {
+  ingredientId: string
+  sellingUnitId: string
+  name: string
+  packageInfo: string
+  priceCents: number | null
+  quantity: number
+  isPantryItem: boolean
+}
+
+export interface StructuredRecipeIngredients {
+  recipeId: string
+  recipeName: string
+  portions: number
+  ingredients: RecipeIngredient[]
+}
+
+export interface RecipeSummary {
+  recipeId: string
+  recipeName: string
+}
+
+export interface ShoppingListItem {
+  sellingUnitId: string
+  name: string
+  packageInfo: string
+  priceCents: number | null
+  quantity: number
+  usedInRecipes: RecipeSummary[]
+}
+
+export interface ShoppingListResult {
+  shoppingList: ShoppingListItem[]
+  sharedItems: ShoppingListItem[]
+  totalPriceCents: number
+  recipesSummary: Array<RecipeSummary & { portions: number }>
+}
+
+export interface MealCombination {
+  recipes: RecipeSummary[]
+  sharedItems: Array<{
+    sellingUnitId: string
+    name: string
+    packageInfo: string
+    usedInRecipes: RecipeSummary[]
+  }>
+  totalPriceCents: number
+  score: number
+  algorithm: "exhaustive" | "greedy"
+}
+
+export interface FindMealCombinationsInput {
+  recipes: StructuredRecipeIngredients[]
+  count: number
+  topK?: number
+  maxTotalBudgetCents?: number
+}
+
+interface SellingUnitContext {
+  ingredientId: string
+  sellingUnitId: string
+  quantity: number
+  checked: boolean
+}
+
+interface RecipeContext {
+  recipeId: string
+  recipeName: string
+  portions: number
+  sellingUnits: SellingUnitContext[]
+}
+
+interface IngredientTile {
+  ingredientId: string
+  name: string
+  packageInfo: string
+  priceCents: number | null
+}
+
+const EXHAUSTIVE_LIMIT = 30_000
+const BUTTON_WORDS = new Set([
+  "add",
+  "ajouter",
+  "ansehen",
+  "bekijken",
+  "hinzufügen",
+  "toevoegen",
+  "view",
+  "voir",
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function cleanLine(line: string): string {
+  return line
+    .replace(/#\([^)]+\)/g, "")
+    .replace(/\[([^\]]+)\]\((?:action|app|https?):\/\/[^)]*\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function collectMarkdowns(value: unknown, acc: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectMarkdowns(item, acc)
+    return
+  }
+  if (!isRecord(value)) return
+  if (typeof value.markdown === "string") {
+    for (const line of value.markdown.split("\n")) {
+      const cleaned = cleanLine(line)
+      if (cleaned) acc.push(cleaned)
+    }
+  }
+  for (const child of Object.values(value)) collectMarkdowns(child, acc)
+}
+
+function parsePriceCents(value: string): number | null {
+  const normalized = value.replace(/\u00a0/g, " ").trim()
+  const match = normalized.match(/(?:€\s*)?(\d+)[,.](\d{2})(?:\s*€)?/)
+  if (!match) return null
+  return Number.parseInt(match[1], 10) * 100 + Number.parseInt(match[2], 10)
+}
+
+function isDisplayNoise(value: string): boolean {
+  const lower = value.toLowerCase()
+  return (
+    BUTTON_WORDS.has(lower) ||
+    /^[-+]?\d+%$/.test(value) ||
+    /^[><%]/.test(value) ||
+    /^\d+[.)]?$/.test(value)
+  )
+}
+
+function extractProductDisplay(
+  ingredientId: string,
+  node: Record<string, unknown>,
+): IngredientTile {
+  const markdowns: string[] = []
+  collectMarkdowns(node.pml ?? node, markdowns)
+
+  const priceIndex = markdowns.findIndex((value) => parsePriceCents(value) !== null)
+  const priceCents = priceIndex >= 0 ? parsePriceCents(markdowns[priceIndex]) : null
+  const nameIndex = markdowns.findIndex(
+    (value, index) => index !== priceIndex && !isDisplayNoise(value),
+  )
+  const packageIndex = markdowns.findIndex(
+    (value, index) => index !== priceIndex && index !== nameIndex && !isDisplayNoise(value),
+  )
+
+  return {
+    ingredientId,
+    name: nameIndex >= 0 ? markdowns[nameIndex] : "",
+    packageInfo: packageIndex >= 0 ? markdowns[packageIndex] : "",
+    priceCents,
+  }
+}
+
+function collectIngredientTiles(pageData: unknown): Map<string, IngredientTile> {
+  const tiles = new Map<string, IngredientTile>()
+
+  function walk(value: unknown, depth: number): void {
+    if (depth > 80 || !isRecord(value)) {
+      if (Array.isArray(value)) {
+        for (const item of value) walk(item, depth + 1)
+      }
+      return
+    }
+
+    const contexts =
+      isRecord(value.analytics) && Array.isArray(value.analytics.contexts)
+        ? value.analytics.contexts
+        : []
+    for (const context of contexts) {
+      if (!isRecord(context) || !isRecord(context.data)) continue
+      if (typeof context.data.product_id !== "string") continue
+      const ingredientId = context.data.product_id
+      if (!tiles.has(ingredientId)) {
+        tiles.set(ingredientId, extractProductDisplay(ingredientId, value))
+      }
+    }
+
+    for (const child of Object.values(value)) walk(child, depth + 1)
+  }
+
+  walk(pageData, 0)
+  return tiles
+}
+
+function parseSellingUnit(value: unknown): SellingUnitContext | null {
+  if (!isRecord(value)) return null
+  if (
+    typeof value.ingredient_id !== "string" ||
+    typeof value.selling_unit_id !== "string" ||
+    typeof value.quantity !== "number" ||
+    typeof value.checked !== "boolean"
+  ) {
+    return null
+  }
+
+  return {
+    ingredientId: value.ingredient_id,
+    sellingUnitId: value.selling_unit_id,
+    quantity: value.quantity,
+    checked: value.checked,
+  }
+}
+
+function parseRecipeContextData(value: unknown): RecipeContext | null {
+  if (!isRecord(value)) return null
+  if (
+    typeof value.recipe_id !== "string" ||
+    typeof value.recipe_name !== "string" ||
+    typeof value.portions !== "number" ||
+    !Array.isArray(value.selling_units)
+  ) {
+    return null
+  }
+
+  const sellingUnits = value.selling_units
+    .map(parseSellingUnit)
+    .filter((unit): unit is SellingUnitContext => unit !== null)
+
+  if (sellingUnits.length === 0) return null
+  return {
+    recipeId: value.recipe_id,
+    recipeName: value.recipe_name,
+    portions: value.portions,
+    sellingUnits,
+  }
+}
+
+function extractRecipeContext(pageData: unknown): RecipeContext | null {
+  function walk(value: unknown, depth: number): RecipeContext | null {
+    if (depth > 80) return null
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const result = walk(item, depth + 1)
+        if (result) return result
+      }
+      return null
+    }
+    if (!isRecord(value)) return null
+
+    const direct = parseRecipeContextData(value)
+    if (direct) return direct
+
+    const contexts =
+      isRecord(value.analytics) && Array.isArray(value.analytics.contexts)
+        ? value.analytics.contexts
+        : []
+    for (const context of contexts) {
+      if (!isRecord(context)) continue
+      const result = parseRecipeContextData(context.data)
+      if (result) return result
+    }
+
+    for (const child of Object.values(value)) {
+      const result = walk(child, depth + 1)
+      if (result) return result
+    }
+    return null
+  }
+
+  return walk(pageData, 0)
+}
+
+export function parseRecipeIngredients(pageData: unknown): StructuredRecipeIngredients | null {
+  const context = extractRecipeContext(pageData)
+  if (!context) return null
+
+  const tiles = collectIngredientTiles(pageData)
+  return {
+    recipeId: context.recipeId,
+    recipeName: context.recipeName,
+    portions: context.portions,
+    ingredients: context.sellingUnits.map((unit) => {
+      const tile = tiles.get(unit.ingredientId)
+      return {
+        ingredientId: unit.ingredientId,
+        sellingUnitId: unit.sellingUnitId,
+        name: tile?.name ?? "",
+        packageInfo: tile?.packageInfo ?? "",
+        priceCents: tile?.priceCents ?? null,
+        quantity: unit.quantity,
+        isPantryItem: !unit.checked,
+      }
+    }),
+  }
+}
+
+function lineTotal(item: Pick<ShoppingListItem, "priceCents" | "quantity">): number {
+  return (item.priceCents ?? 0) * item.quantity
+}
+
+export function buildShoppingList(recipes: StructuredRecipeIngredients[]): ShoppingListResult {
+  const items = new Map<string, ShoppingListItem>()
+
+  for (const recipe of recipes) {
+    const seenInRecipe = new Set<string>()
+    for (const ingredient of recipe.ingredients) {
+      if (ingredient.isPantryItem || seenInRecipe.has(ingredient.sellingUnitId)) continue
+      seenInRecipe.add(ingredient.sellingUnitId)
+
+      const existing = items.get(ingredient.sellingUnitId)
+      const recipeSummary = { recipeId: recipe.recipeId, recipeName: recipe.recipeName }
+      if (existing) {
+        existing.quantity += ingredient.quantity
+        existing.usedInRecipes.push(recipeSummary)
+        if (existing.priceCents === null && ingredient.priceCents !== null) {
+          existing.priceCents = ingredient.priceCents
+        }
+        continue
+      }
+
+      items.set(ingredient.sellingUnitId, {
+        sellingUnitId: ingredient.sellingUnitId,
+        name: ingredient.name,
+        packageInfo: ingredient.packageInfo,
+        priceCents: ingredient.priceCents,
+        quantity: ingredient.quantity,
+        usedInRecipes: [recipeSummary],
+      })
+    }
+  }
+
+  const shoppingList = Array.from(items.values()).sort(
+    (a, b) =>
+      lineTotal(b) - lineTotal(a) ||
+      a.name.localeCompare(b.name) ||
+      a.sellingUnitId.localeCompare(b.sellingUnitId),
+  )
+  const sharedItems = shoppingList.filter((item) => item.usedInRecipes.length > 1)
+
+  return {
+    shoppingList,
+    sharedItems,
+    totalPriceCents: shoppingList.reduce((sum, item) => sum + lineTotal(item), 0),
+    recipesSummary: recipes.map((recipe) => ({
+      recipeId: recipe.recipeId,
+      recipeName: recipe.recipeName,
+      portions: recipe.portions,
+    })),
+  }
+}
+
+function nChooseK(n: number, k: number): number {
+  if (k > n) return 0
+  if (k === 0 || k === n) return 1
+  const limitedK = Math.min(k, n - k)
+  let result = 1
+  for (let index = 1; index <= limitedK; index++) {
+    result = (result * (n - limitedK + index)) / index
+    if (result > EXHAUSTIVE_LIMIT) return result
+  }
+  return Math.round(result)
+}
+
+function scoreCombination(
+  recipes: StructuredRecipeIngredients[],
+  algorithm: "exhaustive" | "greedy",
+): MealCombination {
+  const shoppingList = buildShoppingList(recipes)
+  const sharedItems = shoppingList.sharedItems.map((item) => ({
+    sellingUnitId: item.sellingUnitId,
+    name: item.name,
+    packageInfo: item.packageInfo,
+    usedInRecipes: item.usedInRecipes,
+  }))
+  const score = sharedItems.reduce((sum, item) => sum + item.usedInRecipes.length - 1, 0)
+
+  return {
+    recipes: recipes.map((recipe) => ({
+      recipeId: recipe.recipeId,
+      recipeName: recipe.recipeName,
+    })),
+    sharedItems,
+    totalPriceCents: shoppingList.totalPriceCents,
+    score,
+    algorithm,
+  }
+}
+
+function recipeTieBreaker(recipes: RecipeSummary[]): string {
+  return recipes
+    .map((recipe) => recipe.recipeId)
+    .sort()
+    .join(",")
+}
+
+function compareCombinations(a: MealCombination, b: MealCombination): number {
+  return (
+    b.score - a.score ||
+    a.totalPriceCents - b.totalPriceCents ||
+    recipeTieBreaker(a.recipes).localeCompare(recipeTieBreaker(b.recipes))
+  )
+}
+
+function addCombination(
+  seen: Map<string, MealCombination>,
+  recipes: StructuredRecipeIngredients[],
+  algorithm: "exhaustive" | "greedy",
+  maxTotalBudgetCents: number | undefined,
+): void {
+  const key = recipes
+    .map((recipe) => recipe.recipeId)
+    .sort()
+    .join(",")
+  if (seen.has(key)) return
+
+  const result = scoreCombination(recipes, algorithm)
+  if (maxTotalBudgetCents === undefined || result.totalPriceCents <= maxTotalBudgetCents) {
+    seen.set(key, result)
+  }
+}
+
+export function findMealCombinations(input: FindMealCombinationsInput): MealCombination[] {
+  if (input.count < 2 || input.recipes.length < input.count) return []
+
+  const topK = input.topK ?? 5
+  const seen = new Map<string, MealCombination>()
+  const useExhaustive = nChooseK(input.recipes.length, input.count) <= EXHAUSTIVE_LIMIT
+
+  if (useExhaustive) {
+    function combine(start: number, current: StructuredRecipeIngredients[]): void {
+      if (current.length === input.count) {
+        addCombination(seen, current, "exhaustive", input.maxTotalBudgetCents)
+        return
+      }
+      for (
+        let index = start;
+        index <= input.recipes.length - (input.count - current.length);
+        index++
+      ) {
+        combine(index + 1, [...current, input.recipes[index]])
+      }
+    }
+
+    combine(0, [])
+  } else {
+    for (const start of input.recipes) {
+      const selected = [start]
+      const selectedIds = new Set([start.recipeId])
+
+      while (selected.length < input.count) {
+        let bestRecipe: StructuredRecipeIngredients | null = null
+        let bestCombination: MealCombination | null = null
+
+        for (const candidate of input.recipes) {
+          if (selectedIds.has(candidate.recipeId)) continue
+          const candidateCombination = scoreCombination([...selected, candidate], "greedy")
+          if (!bestCombination || compareCombinations(candidateCombination, bestCombination) < 0) {
+            bestRecipe = candidate
+            bestCombination = candidateCombination
+          }
+        }
+
+        if (!bestRecipe) break
+        selected.push(bestRecipe)
+        selectedIds.add(bestRecipe.recipeId)
+      }
+
+      if (selected.length === input.count) {
+        addCombination(seen, selected, "greedy", input.maxTotalBudgetCents)
+      }
+    }
+  }
+
+  return Array.from(seen.values()).sort(compareCombinations).slice(0, topK)
+}

--- a/test/unit/tools/picnic-recipe-meal-planning-tools.test.ts
+++ b/test/unit/tools/picnic-recipe-meal-planning-tools.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ToolResult } from "../../../src/tools/registry.js"
+
+const mocks = vi.hoisted(() => ({
+  initializePicnicClient: vi.fn(),
+  sendRequest: vi.fn(),
+}))
+
+vi.mock("../../../src/utils/picnic-client.js", () => ({
+  getPicnicClient: () => ({ sendRequest: mocks.sendRequest }),
+  initializePicnicClient: mocks.initializePicnicClient,
+  saveSession: vi.fn(),
+}))
+
+const RECIPE_A = "0123456789abcdef01234567"
+const RECIPE_B = "fedcba9876543210fedcba98"
+
+function parseToolResult(result: ToolResult) {
+  return JSON.parse(result.content[0].text ?? "")
+}
+
+function recipePage(recipeId: string, recipeName: string) {
+  return {
+    body: [
+      {
+        type: "PML",
+        analytics: {
+          contexts: [
+            {
+              data: {
+                recipe_id: recipeId,
+                recipe_name: recipeName,
+                portions: 2,
+                selling_units: [
+                  {
+                    ingredient_id: `ingredient-${recipeId}`,
+                    selling_unit_id: `s-${recipeId}`,
+                    quantity: 2,
+                    checked: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: "PML",
+        analytics: {
+          contexts: [
+            {
+              schema: "iglu:com.picnic/product/1-0-0",
+              data: { product_id: `ingredient-${recipeId}` },
+            },
+          ],
+        },
+        pml: {
+          component: {
+            type: "STACK",
+            children: [
+              { type: "RICH_TEXT", markdown: `${recipeName} ingredient` },
+              { type: "RICH_TEXT", markdown: "500 g" },
+              { type: "RICH_TEXT", markdown: "€1,25" },
+            ],
+          },
+        },
+      },
+    ],
+  }
+}
+
+async function loadTools() {
+  vi.resetModules()
+  const { toolRegistry } = await import("../../../src/tools/registry.js")
+  const registerSpy = vi.spyOn(toolRegistry, "register")
+  await import("../../../src/tools/picnic-tools.js")
+  return { registerSpy, toolRegistry }
+}
+
+describe("recipe meal-planning tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("fetches structured recipe ingredients by URL and requests the encoded selling-group page", async () => {
+    mocks.sendRequest.mockResolvedValue(recipePage(RECIPE_A, "Recipe A"))
+
+    const { toolRegistry } = await loadTools()
+    const result = await toolRegistry.executeTool("picnic_get_recipe_ingredients", {
+      recipe_url_or_id: `https://picnic.app/de/rezepte/${RECIPE_A}/recipe-a`,
+    })
+
+    expect(mocks.sendRequest).toHaveBeenCalledWith(
+      "GET",
+      `/pages/selling-group-details-page?selling_group_id=${encodeURIComponent(RECIPE_A)}`,
+      null,
+      true,
+    )
+    expect(parseToolResult(result)).toEqual({
+      recipeId: RECIPE_A,
+      recipeName: "Recipe A",
+      portions: 2,
+      ingredients: [
+        {
+          ingredientId: `ingredient-${RECIPE_A}`,
+          sellingUnitId: `s-${RECIPE_A}`,
+          name: "Recipe A ingredient",
+          packageInfo: "500 g",
+          priceCents: 125,
+          quantity: 2,
+          isPantryItem: false,
+        },
+      ],
+    })
+  })
+
+  it("returns successes and per-input errors when fetching multiple recipe ingredients", async () => {
+    mocks.sendRequest.mockImplementation((method: string, path: string) => {
+      if (path.includes(RECIPE_B)) throw new Error("Recipe unavailable")
+      return recipePage(RECIPE_A, "Recipe A")
+    })
+
+    const { toolRegistry } = await loadTools()
+    const result = await toolRegistry.executeTool("picnic_get_multiple_recipe_ingredients", {
+      recipe_urls_or_ids: [RECIPE_A, RECIPE_B],
+    })
+
+    expect(parseToolResult(result)).toEqual({
+      recipes: [
+        {
+          recipeId: RECIPE_A,
+          recipeName: "Recipe A",
+          portions: 2,
+          ingredients: [
+            {
+              ingredientId: `ingredient-${RECIPE_A}`,
+              sellingUnitId: `s-${RECIPE_A}`,
+              name: "Recipe A ingredient",
+              packageInfo: "500 g",
+              priceCents: 125,
+              quantity: 2,
+              isPantryItem: false,
+            },
+          ],
+        },
+      ],
+      errors: [{ input: RECIPE_B, error: "Recipe unavailable" }],
+    })
+  })
+
+  it("registers the existing recipe cart tool only once", async () => {
+    const { registerSpy } = await loadTools()
+
+    const recipeCartRegistrations = registerSpy.mock.calls.filter(
+      ([tool]) => tool.name === "picnic_add_recipe_to_cart",
+    )
+
+    expect(recipeCartRegistrations).toHaveLength(1)
+  })
+})

--- a/test/unit/tools/picnic-recipe-meal-planning-tools.test.ts
+++ b/test/unit/tools/picnic-recipe-meal-planning-tools.test.ts
@@ -50,7 +50,7 @@ function recipePage(recipeId: string, recipeName: string) {
           contexts: [
             {
               schema: "iglu:com.picnic/product/1-0-0",
-              data: { product_id: `ingredient-${recipeId}` },
+              data: { product_id: `s-${recipeId}` },
             },
           ],
         },

--- a/test/unit/utils/recipe-meal-planning.test.ts
+++ b/test/unit/utils/recipe-meal-planning.test.ts
@@ -104,9 +104,9 @@ describe("parseRecipeIngredients", () => {
     const parsed = parseRecipeIngredients({
       body: [
         recipeContext(),
-        productTile("ingredient-de", ["Paprika Mix", "500 g", "€2,49"]),
-        productTile("ingredient-nl", ["Tomaten", "1 stuk nodig", "1.19"]),
-        productTile("ingredient-fr", ["Riz basmati", "1 paquet", "2,05 €"]),
+        productTile("s-de", ["Paprika Mix", "500 g", "€2,49"]),
+        productTile("s-nl", ["Tomaten", "1 stuk nodig", "1.19"]),
+        productTile("s-fr", ["Riz basmati", "1 paquet", "2,05 €"]),
       ],
     })
 

--- a/test/unit/utils/recipe-meal-planning.test.ts
+++ b/test/unit/utils/recipe-meal-planning.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildShoppingList,
+  findMealCombinations,
+  parseRecipeIngredients,
+  type StructuredRecipeIngredients,
+} from "../../../src/utils/recipe-meal-planning.js"
+
+const RECIPE_ID = "0123456789abcdef01234567"
+
+function recipeContext(
+  overrides: Partial<{
+    recipe_id: string
+    recipe_name: string
+    portions: number
+    selling_units: Array<{
+      ingredient_id: string
+      selling_unit_id: string
+      quantity: number
+      checked: boolean
+    }>
+  }> = {},
+) {
+  return {
+    type: "PML",
+    analytics: {
+      contexts: [
+        {
+          data: {
+            recipe_id: RECIPE_ID,
+            recipe_name: "Rice pan",
+            portions: 2,
+            selling_units: [
+              {
+                ingredient_id: "ingredient-de",
+                selling_unit_id: "s-de",
+                quantity: 2,
+                checked: true,
+              },
+              {
+                ingredient_id: "ingredient-nl",
+                selling_unit_id: "s-nl",
+                quantity: 1,
+                checked: true,
+              },
+              {
+                ingredient_id: "ingredient-fr",
+                selling_unit_id: "s-fr",
+                quantity: 1,
+                checked: false,
+              },
+            ],
+            ...overrides,
+          },
+        },
+      ],
+    },
+  }
+}
+
+function productTile(ingredientId: string, markdowns: string[]) {
+  return {
+    type: "PML",
+    analytics: {
+      contexts: [{ schema: "iglu:com.picnic/product/1-0-0", data: { product_id: ingredientId } }],
+    },
+    pml: {
+      component: {
+        type: "STACK",
+        children: markdowns.map((markdown) => ({ type: "RICH_TEXT", markdown })),
+      },
+    },
+  }
+}
+
+function recipe(
+  recipeId: string,
+  recipeName: string,
+  ingredients: StructuredRecipeIngredients["ingredients"],
+): StructuredRecipeIngredients {
+  return { recipeId, recipeName, portions: 2, ingredients }
+}
+
+function ingredient(
+  sellingUnitId: string,
+  name: string,
+  priceCents: number,
+  quantity = 1,
+  isPantryItem = false,
+) {
+  return {
+    ingredientId: `ingredient-${sellingUnitId}`,
+    sellingUnitId,
+    name,
+    packageInfo: "1 pack",
+    priceCents,
+    quantity,
+    isPantryItem,
+  }
+}
+
+describe("parseRecipeIngredients", () => {
+  it("extracts structured selling units and locale-neutral product display fields", () => {
+    const parsed = parseRecipeIngredients({
+      body: [
+        recipeContext(),
+        productTile("ingredient-de", ["Paprika Mix", "500 g", "€2,49"]),
+        productTile("ingredient-nl", ["Tomaten", "1 stuk nodig", "1.19"]),
+        productTile("ingredient-fr", ["Riz basmati", "1 paquet", "2,05 €"]),
+      ],
+    })
+
+    expect(parsed).toEqual({
+      recipeId: RECIPE_ID,
+      recipeName: "Rice pan",
+      portions: 2,
+      ingredients: [
+        {
+          ingredientId: "ingredient-de",
+          sellingUnitId: "s-de",
+          name: "Paprika Mix",
+          packageInfo: "500 g",
+          priceCents: 249,
+          quantity: 2,
+          isPantryItem: false,
+        },
+        {
+          ingredientId: "ingredient-nl",
+          sellingUnitId: "s-nl",
+          name: "Tomaten",
+          packageInfo: "1 stuk nodig",
+          priceCents: 119,
+          quantity: 1,
+          isPantryItem: false,
+        },
+        {
+          ingredientId: "ingredient-fr",
+          sellingUnitId: "s-fr",
+          name: "Riz basmati",
+          packageInfo: "1 paquet",
+          priceCents: 205,
+          quantity: 1,
+          isPantryItem: true,
+        },
+      ],
+    })
+  })
+
+  it("returns null when the page does not contain recipe selling-unit analytics", () => {
+    expect(parseRecipeIngredients({ body: [productTile("ingredient", ["Tomatoes"])] })).toBeNull()
+  })
+})
+
+describe("buildShoppingList", () => {
+  it("deduplicates per recipe, skips pantry items, and totals price times quantity", () => {
+    const shoppingList = buildShoppingList([
+      recipe("a", "Pasta", [
+        ingredient("shared", "Pasta", 150, 2),
+        ingredient("shared", "Pasta duplicate", 150, 99),
+        ingredient("pantry", "Salt", 40, 1, true),
+      ]),
+      recipe("b", "Soup", [
+        ingredient("shared", "Pasta", 150, 1),
+        ingredient("tomato", "Tomato", 80, 3),
+      ]),
+    ])
+
+    expect(shoppingList.totalPriceCents).toBe(690)
+    expect(shoppingList.shoppingList).toEqual([
+      {
+        sellingUnitId: "shared",
+        name: "Pasta",
+        packageInfo: "1 pack",
+        priceCents: 150,
+        quantity: 3,
+        usedInRecipes: [
+          { recipeId: "a", recipeName: "Pasta" },
+          { recipeId: "b", recipeName: "Soup" },
+        ],
+      },
+      {
+        sellingUnitId: "tomato",
+        name: "Tomato",
+        packageInfo: "1 pack",
+        priceCents: 80,
+        quantity: 3,
+        usedInRecipes: [{ recipeId: "b", recipeName: "Soup" }],
+      },
+    ])
+    expect(shoppingList.sharedItems.map((item) => item.sellingUnitId)).toEqual(["shared"])
+  })
+})
+
+describe("findMealCombinations", () => {
+  it("uses exhaustive search over the full pool when the combination count is under the limit", () => {
+    const combinations = findMealCombinations({
+      recipes: [
+        recipe("a", "A", [ingredient("x", "X", 100), ingredient("a-only", "A", 100)]),
+        recipe("b", "B", [ingredient("x", "X", 100), ingredient("b-only", "B", 100)]),
+        recipe("c", "C", [ingredient("y", "Y", 100), ingredient("z", "Z", 100)]),
+        recipe("d", "D", [ingredient("y", "Y", 100), ingredient("z", "Z", 100)]),
+      ],
+      count: 2,
+      topK: 1,
+    })
+
+    expect(combinations).toHaveLength(1)
+    expect(combinations[0]).toMatchObject({
+      algorithm: "exhaustive",
+      score: 2,
+      recipes: [
+        { recipeId: "c", recipeName: "C" },
+        { recipeId: "d", recipeName: "D" },
+      ],
+    })
+  })
+
+  it("uses greedy fallback over the full candidate pool when exhaustive search is too large", () => {
+    const recipes = Array.from({ length: 302 }, (_, index) =>
+      recipe(`recipe-${index}`, `Recipe ${index}`, [
+        ingredient(`only-${index}`, `Only ${index}`, 100),
+      ]),
+    )
+    recipes[300] = recipe("late-a", "Late A", [ingredient("late-shared", "Late shared", 100)])
+    recipes[301] = recipe("late-b", "Late B", [ingredient("late-shared", "Late shared", 100)])
+
+    const combinations = findMealCombinations({ recipes, count: 2, topK: 1 })
+
+    expect(combinations[0]).toMatchObject({
+      algorithm: "greedy",
+      score: 1,
+      recipes: [
+        { recipeId: "late-a", recipeName: "Late A" },
+        { recipeId: "late-b", recipeName: "Late B" },
+      ],
+    })
+  })
+
+  it("applies budget filtering using the shopping-list cost calculation", () => {
+    const combinations = findMealCombinations({
+      recipes: [
+        recipe("expensive-a", "Expensive A", [ingredient("shared-expensive", "Expensive", 500, 2)]),
+        recipe("expensive-b", "Expensive B", [ingredient("shared-expensive", "Expensive", 500, 1)]),
+        recipe("cheap-a", "Cheap A", [ingredient("shared-cheap", "Cheap", 100, 1)]),
+        recipe("cheap-b", "Cheap B", [ingredient("shared-cheap", "Cheap", 100, 1)]),
+      ],
+      count: 2,
+      topK: 5,
+      maxTotalBudgetCents: 250,
+    })
+
+    expect(combinations).toHaveLength(1)
+    expect(combinations[0]).toMatchObject({
+      totalPriceCents: 200,
+      recipes: [
+        { recipeId: "cheap-a", recipeName: "Cheap A" },
+        { recipeId: "cheap-b", recipeName: "Cheap B" },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds structured recipe ingredient extraction from selling-group analytics for meal-planning use cases.
- Adds recipe ingredient, multi-recipe ingredient, shopping-list, and meal-combination MCP tools on top of the #42 recipe foundation.
- Keeps the scope focused: no category browsing, no startup wrapper/docs changes, and no duplicate recipe-cart implementation.

Thanks to @wauwi-himbeersternchen for the original recipe meal-planning prototype in #36; this PR carries forward the shopping-list and meal-combination ideas on top of the newer #42 recipe foundation.

## Notes

- Ingredient outputs use camelCase fields to match the merged recipe tools: `recipeId`, `recipeName`, `sellingUnitId`, `ingredientId`, `isPantryItem`, and `priceCents`.
- Shopping-list totals use `priceCents * quantity` and skip pantry items.
- Meal combinations use exhaustive search when the full combination space is small enough, otherwise greedy fallback over the full candidate pool.

## Verification

- `npx vitest run test/unit/utils/recipe-meal-planning.test.ts`
- `npx vitest run test/unit/tools/picnic-recipe-meal-planning-tools.test.ts`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npx prettier --check src/tools/picnic-tools.ts src/utils/recipe-meal-planning.ts test/unit/utils/recipe-meal-planning.test.ts test/unit/tools/picnic-recipe-meal-planning-tools.test.ts`