### PR TITLE
[codex] Fix streamable HTTP session cleanup recursion

### DIFF
--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -489,13 +489,13 @@ export class StreamableHttpServer extends BaseTransportServer {
   public cleanupSession(sessionId: string): void {
     const transport = this.transports[sessionId]
     if (transport) {
-      transport.close()
       delete this.transports[sessionId]
       const timeout = this.sessionTimeouts.get(sessionId)
       if (timeout) {
         clearTimeout(timeout)
         this.sessionTimeouts.delete(sessionId)
       }
+      transport.close()
       this.emit("session-ended", sessionId)
     }
   }

--- a/test/unit/transports/streamable-http.test.ts
+++ b/test/unit/transports/streamable-http.test.ts
@@ -409,4 +409,36 @@ describe("StreamableHttpServer", () => {
 
     expect(sessionsRes.statusCode).toBe(200)
   })
+
+  it("should not recurse when transport close fires onclose during session cleanup", () => {
+    server = new StreamableHttpServer({ enableRequestLogging: false })
+    const sessionId = "regression-session"
+
+    const transport: {
+      sessionId: string
+      closeCalls: number
+      onclose?: () => void
+      close: () => void
+    } = {
+      sessionId,
+      closeCalls: 0,
+      close() {
+        this.closeCalls++
+        this.onclose?.()
+      },
+    }
+
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        server.cleanupSession(transport.sessionId)
+      }
+    }
+
+    // @ts-expect-error - private property access
+    server.transports[sessionId] = transport
+
+    expect(() => server.cleanupSession(sessionId)).not.toThrow()
+    expect(transport.closeCalls).toBe(1)
+    expect(server.getActiveSessions()).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

- fix `cleanupSession()` so sessions are removed before `transport.close()` can fire `onclose`
- add a regression test for the close -> onclose -> cleanupSession recursion path
- preserve the current HTTP token-auth behavior and tests from `main`

Fixes #38.

## Credit

Credit to @mheiland for identifying the root cause and cleanup-order fix in #45. This PR reapplies that fix on current `main` without dropping the newer HTTP auth changes.

## Verification

- `PICNIC_USERNAME=test PICNIC_PASSWORD=test npx vitest run test/unit/transports/streamable-http.test.ts --config vitest.config.ts`
- `PICNIC_USERNAME=test PICNIC_PASSWORD=test npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`