### PR TITLE
[codex] clarify removed category tool docs

### DIFF
--- a/PICNIC_TOOLS.md
+++ b/PICNIC_TOOLS.md
@@ -42,19 +42,35 @@ Get product suggestions based on a query.
 
 - `query` (string): Query for product suggestions
 
+#### `picnic_get_product_details`
+
+Look up product details by selling unit ID.
+
+**Parameters:**
+
+- `productId` (string): The product selling unit ID returned by search or cart
+- `full` (boolean, optional): Return full product details, including description, allergens, nutritional info, promotions, and similar products
+
+#### `picnic_get_image`
+
+Get product image data.
+
+**Parameters:**
+
+- `imageId` (string): The image ID returned by search, cart, or product details
+- `size` (string): Image size (`tiny`, `small`, `medium`, `large`, or `extra-large`)
+
+### Removed Legacy Product Tools
+
 #### ~~`picnic_get_article`~~ (REMOVED)
 
 **This tool has been removed** because the Picnic API deprecated product detail endpoints. See [GitHub issue #23](https://github.com/MRVDH/picnic-api/issues/23).
 
-**Alternative:** Use `picnic_search` to get basic product information (id, name, price, unit).
+**Alternative:** Use `picnic_get_product_details` for product details or `picnic_search` for basic product information (id, name, price, unit).
 
-#### `picnic_get_categories`
+#### ~~`picnic_get_categories`~~ (REMOVED)
 
-Get product categories from Picnic.
-
-**Parameters:**
-
-- `depth` (number, optional): Category depth to retrieve (0-5, default: 0)
+**This tool is not available** because `picnic-api` v4 removed the underlying `getCategories()` function. Category browsing would require a new Fusion page implementation.
 
 ### Shopping Cart Management
 
@@ -157,26 +173,6 @@ Get details of the current logged-in user.
 
 Get user information including toggled features.
 
-### Lists Management
-
-#### `picnic_get_lists`
-
-Get shopping lists and sublists.
-
-**Parameters:**
-
-- `depth` (number, optional): List depth to retrieve (0-5, default: 0)
-
-#### `picnic_get_list`
-
-Get a specific list or sublist with its items.
-
-**Parameters:**
-
-- `listId` (string): The ID of the list to get
-- `subListId` (string, optional): The ID of the sub list to get
-- `depth` (number, optional): List depth to retrieve (0-5, default: 0)
-
 ### Payment & Transactions
 
 #### `picnic_get_payment_profile`
@@ -199,11 +195,9 @@ Get detailed information about a specific wallet transaction.
 
 - `transactionId` (string): The ID of the transaction to get details for
 
-### Other
+### Other Removed Legacy Tools
 
-#### `picnic_get_mgm_details`
-
-Get MGM (friends discount) details.
+The legacy `picnic_get_lists`, `picnic_get_list`, and `picnic_get_mgm_details` tools are not available because `picnic-api` v4 removed their backing APIs.
 
 ## Usage Example
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ User: "I want to make lasagna but need gluten-free and dairy-free alternatives"
 AI Actions:
 1. Uses picnic_search to find gluten-free pasta
 2. Uses picnic_get_suggestions for dairy-free cheese alternatives
-3. Uses picnic_get_article to check ingredient details
+3. Uses picnic_get_product_details to check ingredient details
 4. Uses picnic_add_to_cart to add suitable products
 5. Provides cooking tips and substitution ratios
 ```
@@ -177,7 +177,7 @@ User: "I have €50 for groceries this week, help me maximize value"
 
 AI Actions:
 1. Uses picnic_search to find budget-friendly staples
-2. Uses picnic_get_categories to explore discount sections
+2. Uses picnic_get_product_details to inspect prices, package sizes, and promotions
 3. Uses picnic_get_cart to track running total
 4. Uses picnic_remove_from_cart if budget exceeded
 5. Uses picnic_get_wallet_transactions to track spending patterns
@@ -191,11 +191,11 @@ AI Actions:
 User: "Create separate shopping lists for weekly groceries and party supplies"
 
 AI Actions:
-1. Uses picnic_get_lists to view existing lists
-2. Uses picnic_get_list to check current items
-3. Uses picnic_search to find party-specific items
-4. Organizes items by category using picnic_get_categories
-5. Uses picnic_add_to_cart when ready to order
+1. Uses picnic_search to find weekly grocery staples
+2. Uses picnic_search to find party-specific items
+3. Uses picnic_get_product_details to check pack sizes and ingredients
+4. Uses picnic_add_to_cart when ready to order
+5. Uses picnic_get_cart to review totals before checkout
 ```
 
 ### 🎉 **Event Planning**
@@ -210,7 +210,7 @@ AI Actions:
 2. Uses picnic_get_suggestions for wine pairings
 3. Uses picnic_get_delivery_slots to schedule Friday delivery
 4. Uses picnic_set_delivery_slot to book optimal time
-5. Uses picnic_get_article to check product availability and sizes
+5. Uses picnic_get_product_details to check product availability and sizes
 ```
 
 ### 🥗 **Health & Dietary Management**
@@ -222,7 +222,7 @@ User: "Find low-carb options for a diabetic-friendly weekly menu"
 
 AI Actions:
 1. Uses picnic_search with specific dietary keywords
-2. Uses picnic_get_article to check nutritional information
+2. Uses picnic_get_product_details to check nutritional information
 3. Uses picnic_get_suggestions for healthy alternatives
 4. Uses picnic_add_to_cart for approved items only
 5. Tracks nutritional goals across multiple meals
@@ -252,9 +252,9 @@ User: "Compare prices for organic vs conventional produce this week"
 
 AI Actions:
 1. Uses picnic_search for both organic and conventional items
-2. Uses picnic_get_article to compare prices and sizes
-3. Uses picnic_get_categories to explore different brands
-4. Uses picnic_get_suggestions for similar products
+2. Uses picnic_get_product_details to compare prices and sizes
+3. Uses picnic_get_suggestions for similar brands and products
+4. Uses picnic_get_cart to compare basket totals
 5. Provides detailed cost analysis and recommendations
 ```
 
@@ -270,7 +270,7 @@ AI Actions:
 2. Uses picnic_get_delivery_scenario for driver communication
 3. Uses picnic_rate_delivery after completion
 4. Uses picnic_send_delivery_invoice_email for records
-5. Uses picnic_get_mgm_details to share referral benefits
+5. Uses picnic_get_order_status to confirm final order state
 ```
 
 ### 💳 **Financial Tracking**
@@ -521,7 +521,7 @@ When 2FA is pending, the server stays up so your client can complete `picnic_gen
 
 ## Available Tools
 
-The server provides comprehensive access to Picnic's functionality through 25+ specialized tools:
+The server provides comprehensive access to Picnic's functionality through 30+ specialized tools:
 
 ### Authentication & Account Management
 
@@ -536,9 +536,25 @@ The server provides comprehensive access to Picnic's functionality through 25+ s
 
 - **`picnic_search`** - Search for products by name or keywords
 - **`picnic_get_suggestions`** - Get product suggestions based on query
-- **`picnic_get_article`** - Get detailed information about a specific product
+- **`picnic_get_product_details`** - Get detailed information about a specific product
 - **`picnic_get_image`** - Get product images in various sizes (tiny to extra-large)
-- **`picnic_get_categories`** - Browse product categories with configurable depth
+
+**Note**: `picnic_get_categories` is not available. The underlying `picnic-api` package removed `getCategories()` in v4; category browsing would need a new Fusion page implementation.
+
+### Recipe & Meal Planning
+
+- **`picnic_browse_recipes`** - Browse Picnic recipes
+- **`picnic_get_recipe`** - Get details for a specific recipe
+- **`picnic_get_recipe_ingredients`** - Extract recipe ingredients
+- **`picnic_get_multiple_recipe_ingredients`** - Extract ingredients from multiple recipes
+- **`picnic_build_shopping_list`** - Build a consolidated shopping list
+- **`picnic_find_meal_combinations`** - Find meal combinations within constraints
+- **`picnic_add_recipe_to_cart`** - Add recipe ingredients to the cart
+- **`picnic_remove_recipe_from_cart`** - Remove recipe ingredients from the cart
+- **`picnic_get_saved_recipes`** - Get saved recipes
+- **`picnic_get_own_recipes`** - Get user-created recipes
+- **`picnic_save_recipe`** - Save a recipe
+- **`picnic_unsave_recipe`** - Remove a saved recipe
 
 ### Shopping Cart Management
 
@@ -560,17 +576,11 @@ The server provides comprehensive access to Picnic's functionality through 25+ s
 - **`picnic_send_delivery_invoice_email`** - Send/resend delivery invoice emails
 - **`picnic_get_order_status`** - Check status of specific orders
 
-### Lists & Organization
-
-- **`picnic_get_lists`** - Get shopping lists and sublists with configurable depth
-- **`picnic_get_list`** - Get specific list or sublist with all items
-
 ### Payment & Financial
 
 - **`picnic_get_payment_profile`** - View payment methods and billing information
 - **`picnic_get_wallet_transactions`** - Get wallet transaction history (paginated)
 - **`picnic_get_wallet_transaction_details`** - Get detailed transaction information
-- **`picnic_get_mgm_details`** - Get MGM (friends discount) program details
 
 ## Development
 
@@ -800,7 +810,7 @@ Gebruiker: "Ik wil lasagne maken maar heb glutenvrije en zuivelvrije alternatiev
 AI Acties:
 1. Gebruikt picnic_search om glutenvrije pasta te vinden
 2. Gebruikt picnic_get_suggestions voor zuivelvrije kaas alternatieven
-3. Gebruikt picnic_get_article om ingrediënt details te controleren
+3. Gebruikt picnic_get_product_details om ingrediënt details te controleren
 4. Gebruikt picnic_add_to_cart om geschikte producten toe te voegen
 5. Geeft kooktips en vervangingsverhoudingen
 ```
@@ -829,7 +839,7 @@ Gebruiker: "Ik heb €50 voor boodschappen deze week, help me de waarde te maxim
 
 AI Acties:
 1. Gebruikt picnic_search om budget-vriendelijke basisproducten te vinden
-2. Gebruikt picnic_get_categories om kortingssecties te verkennen
+2. Gebruikt picnic_get_product_details om prijzen, verpakkingsmaten en promoties te controleren
 3. Gebruikt picnic_get_cart om lopend totaal bij te houden
 4. Gebruikt picnic_remove_from_cart als budget overschreden wordt
 5. Gebruikt picnic_get_wallet_transactions om uitgavenpatronen te volgen
@@ -843,11 +853,11 @@ AI Acties:
 Gebruiker: "Maak aparte boodschappenlijsten voor wekelijkse boodschappen en feestbenodigdheden"
 
 AI Acties:
-1. Gebruikt picnic_get_lists om bestaande lijsten te bekijken
-2. Gebruikt picnic_get_list om huidige items te controleren
-3. Gebruikt picnic_search om feest-specifieke items te vinden
-4. Organiseert items per categorie met picnic_get_categories
-5. Gebruikt picnic_add_to_cart wanneer klaar om te bestellen
+1. Gebruikt picnic_search om wekelijkse basisboodschappen te vinden
+2. Gebruikt picnic_search om feest-specifieke items te vinden
+3. Gebruikt picnic_get_product_details om verpakkingsmaten en ingrediënten te controleren
+4. Gebruikt picnic_add_to_cart wanneer klaar om te bestellen
+5. Gebruikt picnic_get_cart om totalen voor het afrekenen te controleren
 ```
 
 ### 🎉 **Evenement Planning**
@@ -862,7 +872,7 @@ AI Acties:
 2. Gebruikt picnic_get_suggestions voor wijn combinaties
 3. Gebruikt picnic_get_delivery_slots om vrijdag bezorging in te plannen
 4. Gebruikt picnic_set_delivery_slot om optimale tijd te boeken
-5. Gebruikt picnic_get_article om product beschikbaarheid en maten te controleren
+5. Gebruikt picnic_get_product_details om product beschikbaarheid en maten te controleren
 ```
 
 ### 🥗 **Gezondheid & Dieet Beheer**
@@ -874,7 +884,7 @@ Gebruiker: "Vind koolhydraatarme opties voor een diabetesvriendelijk weekmenu"
 
 AI Acties:
 1. Gebruikt picnic_search met specifieke dieet zoekwoorden
-2. Gebruikt picnic_get_article om voedingswaarde informatie te controleren
+2. Gebruikt picnic_get_product_details om voedingswaarde informatie te controleren
 3. Gebruikt picnic_get_suggestions voor gezonde alternatieven
 4. Gebruikt picnic_add_to_cart alleen voor goedgekeurde items
 5. Volgt voedingsdoelen over meerdere maaltijden
@@ -904,9 +914,9 @@ Gebruiker: "Vergelijk prijzen voor biologische vs conventionele groenten deze we
 
 AI Acties:
 1. Gebruikt picnic_search voor zowel biologische als conventionele items
-2. Gebruikt picnic_get_article om prijzen en maten te vergelijken
-3. Gebruikt picnic_get_categories om verschillende merken te verkennen
-4. Gebruikt picnic_get_suggestions voor vergelijkbare producten
+2. Gebruikt picnic_get_product_details om prijzen en maten te vergelijken
+3. Gebruikt picnic_get_suggestions voor vergelijkbare merken en producten
+4. Gebruikt picnic_get_cart om mandtotalen te vergelijken
 5. Geeft gedetailleerde kostenanalyse en aanbevelingen
 ```
 
@@ -922,7 +932,7 @@ AI Acties:
 2. Gebruikt picnic_get_delivery_scenario voor chauffeur communicatie
 3. Gebruikt picnic_rate_delivery na voltooiing
 4. Gebruikt picnic_send_delivery_invoice_email voor administratie
-5. Gebruikt picnic_get_mgm_details om doorverwijsvoordelen te delen
+5. Gebruikt picnic_get_order_status om de uiteindelijke bestelstatus te bevestigen
 ```
 
 ### 💳 **Financiële Tracking**
@@ -1119,7 +1129,7 @@ Benutzer: "Ich möchte Lasagne machen, brauche aber glutenfreie und milchfreie A
 KI-Aktionen:
 1. Verwendet picnic_search um glutenfreie Pasta zu finden
 2. Verwendet picnic_get_suggestions für milchfreie Käse-Alternativen
-3. Verwendet picnic_get_article um Zutatdetails zu prüfen
+3. Verwendet picnic_get_product_details um Zutatdetails zu prüfen
 4. Verwendet picnic_add_to_cart um geeignete Produkte hinzuzufügen
 5. Gibt Kochtipps und Ersatzverhältnisse
 ```
@@ -1148,7 +1158,7 @@ Benutzer: "Ich habe €50 für Lebensmittel diese Woche, hilf mir den Wert zu ma
 
 KI-Aktionen:
 1. Verwendet picnic_search um budgetfreundliche Grundnahrungsmittel zu finden
-2. Verwendet picnic_get_categories um Rabattbereiche zu erkunden
+2. Verwendet picnic_get_product_details um Preise, Packungsgrößen und Aktionen zu prüfen
 3. Verwendet picnic_get_cart um laufende Gesamtsumme zu verfolgen
 4. Verwendet picnic_remove_from_cart wenn Budget überschritten wird
 5. Verwendet picnic_get_wallet_transactions um Ausgabenmuster zu verfolgen
@@ -1162,11 +1172,11 @@ KI-Aktionen:
 Benutzer: "Erstelle separate Einkaufslisten für wöchentliche Lebensmittel und Partybedarf"
 
 KI-Aktionen:
-1. Verwendet picnic_get_lists um bestehende Listen anzuzeigen
-2. Verwendet picnic_get_list um aktuelle Artikel zu überprüfen
-3. Verwendet picnic_search um party-spezifische Artikel zu finden
-4. Organisiert Artikel nach Kategorien mit picnic_get_categories
-5. Verwendet picnic_add_to_cart wenn bereit zum Bestellen
+1. Verwendet picnic_search um wöchentliche Grundnahrungsmittel zu finden
+2. Verwendet picnic_search um party-spezifische Artikel zu finden
+3. Verwendet picnic_get_product_details um Packungsgrößen und Zutaten zu prüfen
+4. Verwendet picnic_add_to_cart wenn bereit zum Bestellen
+5. Verwendet picnic_get_cart um Gesamtsummen vor dem Checkout zu prüfen
 ```
 
 ### 🎉 **Veranstaltungsplanung**
@@ -1181,7 +1191,7 @@ KI-Aktionen:
 2. Verwendet picnic_get_suggestions für Weinpaarungen
 3. Verwendet picnic_get_delivery_slots um Freitag-Lieferung zu planen
 4. Verwendet picnic_set_delivery_slot um optimale Zeit zu buchen
-5. Verwendet picnic_get_article um Produktverfügbarkeit und Größen zu prüfen
+5. Verwendet picnic_get_product_details um Produktverfügbarkeit und Größen zu prüfen
 ```
 
 ### 🥗 **Gesundheits- & Diätmanagement**
@@ -1193,7 +1203,7 @@ Benutzer: "Finde kohlenhydratarme Optionen für ein diabetikerfreundliches Woche
 
 KI-Aktionen:
 1. Verwendet picnic_search mit spezifischen Diät-Suchbegriffen
-2. Verwendet picnic_get_article um Nährwertinformationen zu prüfen
+2. Verwendet picnic_get_product_details um Nährwertinformationen zu prüfen
 3. Verwendet picnic_get_suggestions für gesunde Alternativen
 4. Verwendet picnic_add_to_cart nur für genehmigte Artikel
 5. Verfolgt Ernährungsziele über mehrere Mahlzeiten
@@ -1223,9 +1233,9 @@ Benutzer: "Vergleiche Preise für Bio- vs. konventionelles Gemüse diese Woche"
 
 KI-Aktionen:
 1. Verwendet picnic_search für sowohl Bio- als auch konventionelle Artikel
-2. Verwendet picnic_get_article um Preise und Größen zu vergleichen
-3. Verwendet picnic_get_categories um verschiedene Marken zu erkunden
-4. Verwendet picnic_get_suggestions für ähnliche Produkte
+2. Verwendet picnic_get_product_details um Preise und Größen zu vergleichen
+3. Verwendet picnic_get_suggestions für ähnliche Marken und Produkte
+4. Verwendet picnic_get_cart um Warenkorbsummen zu vergleichen
 5. Bietet detaillierte Kostenanalyse und Empfehlungen
 ```
 
@@ -1241,7 +1251,7 @@ KI-Aktionen:
 2. Verwendet picnic_get_delivery_scenario für Fahrerkommunikation
 3. Verwendet picnic_rate_delivery nach Abschluss
 4. Verwendet picnic_send_delivery_invoice_email für Aufzeichnungen
-5. Verwendet picnic_get_mgm_details um Empfehlungsvorteile zu teilen
+5. Verwendet picnic_get_order_status um den endgültigen Bestellstatus zu bestätigen
 ```
 
 ### 💳 **Finanzielle Verfolgung**


### PR DESCRIPTION
## Summary

- remove live README references to removed legacy tools such as `picnic_get_categories`, `picnic_get_article`, lists, and MGM
- point product/category-related examples toward current tools like `picnic_search`, `picnic_get_suggestions`, `picnic_get_product_details`, and cart/order tools
- update `PICNIC_TOOLS.md` to document `picnic_get_product_details` / `picnic_get_image` and explicitly mark `picnic_get_categories` as removed

## Why

Issue #30 reported that `picnic_get_categories` was documented but missing from the MCP tool list. The current `picnic-api` v4 package removed the underlying `getCategories()` function, so category browsing is no longer a simple missing registration fix. A future replacement would need a Fusion page-based implementation.

## Validation

- `npm run typecheck`
- docs scan confirming removed category references remain only as removal notes
- `git diff --check -- README.md PICNIC_TOOLS.md`

Refs #30