### PR TITLE
[codex] fix 2FA verification timeout

### DIFF
--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1,6 +1,11 @@
 import { z } from "zod"
 import { toolRegistry } from "./registry.js"
-import { getPicnicClient, initializePicnicClient, saveSession } from "../utils/picnic-client.js"
+import {
+  getPicnicClient,
+  initializePicnicClient,
+  saveSession,
+  verifyPicnic2FACode,
+} from "../utils/picnic-client.js"
 import {
   resolveRecipeId,
   parseSellingGroupRecipe,
@@ -972,11 +977,7 @@ toolRegistry.register({
   inputSchema: verify2FAInputSchema,
   handler: async (args) => {
     await ensureClientInitialized()
-    const client = getPicnicClient()
-
-    // verify2FACode replaces the client's auth key with the refreshed one from
-    // the response, so the session must be persisted again afterwards.
-    await client.auth.verify2FACode(args.code)
+    await verifyPicnic2FACode(args.code)
     await saveSession()
 
     return {

--- a/src/utils/picnic-client.ts
+++ b/src/utils/picnic-client.ts
@@ -63,6 +63,56 @@ export async function saveSession(): Promise<void> {
   }
 }
 
+export async function verifyPicnic2FACode(
+  code: string,
+  timeoutMs: number = 30000,
+): Promise<{ authKey: string }> {
+  const client = getPicnicClient()
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetch(`${client.url}/user/2fa/verify`, {
+      method: "POST",
+      headers: new Headers({
+        ...client.baseHeaders,
+        ...client.picnicHeaders,
+      }),
+      body: JSON.stringify({ otp: code }),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      try {
+        const errorData = JSON.parse(body)
+        const message = errorData.error?.message || response.statusText
+        throw new Error(`2FA verification failed: ${message}`)
+      } catch (error) {
+        if (error instanceof Error && !(error instanceof SyntaxError)) {
+          throw error
+        }
+        throw new Error(`2FA verification failed: ${response.status} ${response.statusText}`)
+      }
+    }
+
+    const authKey = response.headers.get("x-picnic-auth")
+    if (!authKey) {
+      throw new Error("2FA verification failed: No auth key received.")
+    }
+
+    client.authKey = authKey
+    return { authKey }
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`2FA verification timed out after ${timeoutMs}ms`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 export async function initializePicnicClient(
   username?: string,
   password?: string,

--- a/test/unit/tools/picnic-2fa-tools.test.ts
+++ b/test/unit/tools/picnic-2fa-tools.test.ts
@@ -2,18 +2,18 @@ import { describe, it, expect, beforeEach, vi } from "vitest"
 
 // Mock the picnic client wrapper so no real API calls are made
 const mockGenerate2FACode = vi.fn()
-const mockVerify2FACode = vi.fn()
+const mockVerifyPicnic2FACode = vi.fn()
 const mockSaveSession = vi.fn()
 
 vi.mock("../../../src/utils/picnic-client.js", () => ({
   getPicnicClient: () => ({
     auth: {
       generate2FACode: mockGenerate2FACode,
-      verify2FACode: mockVerify2FACode,
     },
   }),
   initializePicnicClient: vi.fn(),
   saveSession: () => mockSaveSession(),
+  verifyPicnic2FACode: (code: string) => mockVerifyPicnic2FACode(code),
 }))
 
 async function getRegistry() {
@@ -60,18 +60,18 @@ describe("picnic 2FA tools", () => {
 
   describe("picnic_verify_2fa_code", () => {
     it("should verify the code and persist the refreshed session", async () => {
-      mockVerify2FACode.mockResolvedValue({ authKey: "refreshed-auth-key" })
+      mockVerifyPicnic2FACode.mockResolvedValue({ authKey: "refreshed-auth-key" })
 
       const registry = await getRegistry()
       const result = await registry.executeTool("picnic_verify_2fa_code", { code: "123456" })
 
-      expect(mockVerify2FACode).toHaveBeenCalledWith("123456")
+      expect(mockVerifyPicnic2FACode).toHaveBeenCalledWith("123456")
       expect(mockSaveSession).toHaveBeenCalled()
       expect(result.content[0].text).toContain("2FA code verified")
     })
 
     it("should propagate verification failures without saving the session", async () => {
-      mockVerify2FACode.mockRejectedValue(new Error("2FA verification failed: invalid code"))
+      mockVerifyPicnic2FACode.mockRejectedValue(new Error("2FA verification failed: invalid code"))
 
       const registry = await getRegistry()
       await expect(registry.executeTool("picnic_verify_2fa_code", { code: "000000" })).rejects.toThrow(

--- a/test/unit/utils/picnic-client.test.ts
+++ b/test/unit/utils/picnic-client.test.ts
@@ -19,6 +19,9 @@ vi.mock("picnic-api", () => {
       auth: { login: mockLogin },
       cart: { getCart: mockGetCart },
       authKey: opts?.authKey ?? "fresh-auth-key",
+      url: "https://example.test/api/15",
+      baseHeaders: { "x-picnic-auth": opts?.authKey ?? "fresh-auth-key" },
+      picnicHeaders: { "x-picnic-agent": "agent", "x-picnic-did": "device" },
     })),
   }
 })
@@ -36,6 +39,7 @@ vi.mock("../../../src/config.js", () => ({
 describe("picnic-client session persistence", () => {
   beforeEach(async () => {
     vi.clearAllMocks()
+    vi.unstubAllGlobals()
     // Reset the module to clear the singleton between tests
     vi.resetModules()
   })
@@ -149,6 +153,29 @@ describe("picnic-client session persistence", () => {
       await saveSession()
 
       expect(fs.writeFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("verifyPicnic2FACode", () => {
+    it("should timeout a stalled 2FA verification request", async () => {
+      vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"))
+      mockLogin.mockResolvedValue(undefined)
+
+      const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          )
+        })
+      })
+      vi.stubGlobal("fetch", fetchMock)
+
+      const { initializePicnicClient, verifyPicnic2FACode } = await importClient()
+      await initializePicnicClient()
+
+      await expect(verifyPicnic2FACode("123456", 1)).rejects.toThrow(
+        "2FA verification timed out after 1ms",
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

- Add an abortable `verifyPicnic2FACode()` wrapper for `/user/2fa/verify`.
- Route `picnic_verify_2fa_code` through the bounded verifier before saving the refreshed session.
- Add regression coverage for a stalled 2FA verification request and update the tool tests to mock the new boundary.

## Root Cause

During live fresh-session 2FA testing, `picnic_generate_2fa_code` sent the SMS, but verification could hang. `picnic-api@4.5.0` implements `verify2FACode()` with raw `fetch()` and no abort signal, so a stalled Picnic verify request can leave the MCP call waiting instead of returning a clear failure.

## Validation

- `npx vitest run test/unit/utils/picnic-client.test.ts test/unit/tools/picnic-2fa-tools.test.ts --config vitest.config.ts` (`19` tests passed)
- `npm run typecheck`
- `npm run lint`
- `npm test` (`15` files / `234` tests passed)
- `npm run build`
- `git diff --check`

Live note: the fresh 2FA retest could not be completed through Codex's interactive stdin path, but the original hang was reproduced during live auth probing and the timeout behavior is covered with a stalled-fetch regression test.