### PR TITLE
feat: persist an auto-generated device id when PICNIC_DEVICE_ID is unset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,11 @@ RUN addgroup -S -g ${APP_UID} mcp \
   && mkdir -p /app/data \
   && chown -R mcp:mcp /app
 
-# Default session location inside the container (can be overridden)
+# Default session and device-id locations inside the container (can be
+# overridden). Both live on the persisted /app/data volume so the generated
+# device id survives container restarts instead of being regenerated each run.
 ENV PICNIC_SESSION_FILE=/app/data/picnic-session.json
+ENV PICNIC_DEVICE_FILE=/app/data/picnic-device.json
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Notes:
 - The container runs as a non-root user (UID `1638`).
 - Session persistence is configured via volume `picnic-data` mapped to `/app/data`.
 - `PICNIC_SESSION_FILE` defaults to `/app/data/picnic-session.json` in the container.
+- `PICNIC_DEVICE_FILE` defaults to `/app/data/picnic-device.json` in the container, so a generated device id is persisted on the same volume and reused across restarts.
 
 ### Configuration
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import dotenv from "dotenv"
 dotenv.config()
 
 const defaultSessionFile = path.join(os.homedir(), ".picnic-session.json")
+const defaultDeviceFile = path.join(os.homedir(), ".picnic-device.json")
 
 const configSchema = z.object({
   PICNIC_USERNAME: z.string(),
@@ -13,6 +14,7 @@ const configSchema = z.object({
   PICNIC_COUNTRY_CODE: z.enum(["NL", "DE", "FR"]).default("NL"),
   PICNIC_API_VERSION: z.string().default("15"),
   PICNIC_DEVICE_ID: z.string().optional(),
+  PICNIC_DEVICE_FILE: z.string().default(defaultDeviceFile),
   PICNIC_AGENT: z.string().optional(),
   ENABLE_HTTP_SERVER: z
     .string()

--- a/src/utils/device-id.ts
+++ b/src/utils/device-id.ts
@@ -1,0 +1,37 @@
+import crypto from "crypto"
+import fs from "fs/promises"
+import { config } from "../config.js"
+
+/**
+ * Resolve the device id used for the x-picnic-did header.
+ *
+ * Precedence:
+ *   1. PICNIC_DEVICE_ID, when explicitly set.
+ *   2. A previously persisted id read from PICNIC_DEVICE_FILE.
+ *   3. A freshly generated id, persisted to PICNIC_DEVICE_FILE for reuse.
+ *
+ * This gives every installation a stable, per-install device fingerprint
+ * without requiring any configuration, instead of falling back to picnic-api's
+ * shared default device id.
+ */
+export async function resolveDeviceId(): Promise<string> {
+  if (config.PICNIC_DEVICE_ID) {
+    return config.PICNIC_DEVICE_ID
+  }
+
+  try {
+    const data = await fs.readFile(config.PICNIC_DEVICE_FILE, "utf-8")
+    const { deviceId } = JSON.parse(data)
+    if (deviceId) return deviceId
+  } catch {
+    // No persisted id yet; fall through to generation.
+  }
+
+  const deviceId = crypto.randomBytes(8).toString("hex").toUpperCase()
+  try {
+    await fs.writeFile(config.PICNIC_DEVICE_FILE, JSON.stringify({ deviceId }))
+  } catch {
+    // If persistence fails, still use the generated id for this run.
+  }
+  return deviceId
+}

--- a/src/utils/picnic-client.ts
+++ b/src/utils/picnic-client.ts
@@ -1,6 +1,7 @@
 import PicnicClient from "picnic-api"
 import fs from "fs/promises"
 import { config } from "../config.js"
+import { resolveDeviceId } from "./device-id.js"
 
 // Singleton instance for caching
 let picnicClientInstance: InstanceType<typeof PicnicClient> | null = null
@@ -129,12 +130,13 @@ export async function initializePicnicClient(
   const loginCountryCode = countryCode || config.PICNIC_COUNTRY_CODE
 
   const savedAuthKey = await loadSession()
+  const deviceId = await resolveDeviceId()
 
   const client = new PicnicClient({
     countryCode: loginCountryCode,
     apiVersion: apiVersion || config.PICNIC_API_VERSION,
     authKey: savedAuthKey ?? undefined,
-    deviceId: config.PICNIC_DEVICE_ID,
+    deviceId,
     agent: config.PICNIC_AGENT,
   })
 

--- a/test/unit/utils/device-id.test.ts
+++ b/test/unit/utils/device-id.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import fs from "fs/promises"
+
+// Mock fs/promises
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}))
+
+// Mutable config mock so each test can vary the relevant fields. Declared via
+// vi.hoisted so it is available inside the hoisted vi.mock factory below.
+const mockConfig = vi.hoisted(
+  () =>
+    ({
+      PICNIC_DEVICE_ID: undefined,
+      PICNIC_DEVICE_FILE: "picnic-device.json",
+    }) as { PICNIC_DEVICE_ID?: string; PICNIC_DEVICE_FILE: string },
+)
+vi.mock("../../../src/config.js", () => ({ config: mockConfig }))
+
+import { resolveDeviceId } from "../../../src/utils/device-id.js"
+
+describe("resolveDeviceId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConfig.PICNIC_DEVICE_ID = undefined
+    mockConfig.PICNIC_DEVICE_FILE = "picnic-device.json"
+  })
+
+  it("returns the explicit PICNIC_DEVICE_ID without touching the filesystem", async () => {
+    mockConfig.PICNIC_DEVICE_ID = "3C417201548B2E3B"
+
+    const id = await resolveDeviceId()
+
+    expect(id).toBe("3C417201548B2E3B")
+    expect(fs.readFile).not.toHaveBeenCalled()
+    expect(fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("returns a persisted id from PICNIC_DEVICE_FILE when present", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ deviceId: "PERSISTED12345AB" }))
+
+    const id = await resolveDeviceId()
+
+    expect(id).toBe("PERSISTED12345AB")
+    expect(fs.readFile).toHaveBeenCalledWith("picnic-device.json", "utf-8")
+    expect(fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("generates and persists a new id when no file exists", async () => {
+    vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"))
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+
+    const id = await resolveDeviceId()
+
+    // 8 random bytes -> 16 uppercase hex characters.
+    expect(id).toMatch(/^[0-9A-F]{16}$/)
+    expect(fs.writeFile).toHaveBeenCalledTimes(1)
+    const [file, payload] = vi.mocked(fs.writeFile).mock.calls[0]
+    expect(file).toBe("picnic-device.json")
+    expect(JSON.parse(payload as string)).toEqual({ deviceId: id })
+  })
+
+  it("falls through to generation when the persisted file has no deviceId", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ somethingElse: true }))
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+
+    const id = await resolveDeviceId()
+
+    expect(id).toMatch(/^[0-9A-F]{16}$/)
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      "picnic-device.json",
+      expect.stringContaining("deviceId"),
+    )
+  })
+
+  it("still returns a usable id when persistence fails", async () => {
+    vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"))
+    vi.mocked(fs.writeFile).mockRejectedValue(new Error("EACCES"))
+
+    const id = await resolveDeviceId()
+
+    expect(id).toMatch(/^[0-9A-F]{16}$/)
+    expect(fs.writeFile).toHaveBeenCalled()
+  })
+})

--- a/test/unit/utils/picnic-client.test.ts
+++ b/test/unit/utils/picnic-client.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../../src/config.js", () => ({
     PICNIC_PASSWORD: "test-pass",
     PICNIC_COUNTRY_CODE: "NL",
     PICNIC_SESSION_FILE: "picnic-session.json",
+    PICNIC_DEVICE_FILE: "picnic-device.json",
   },
 }))
 
@@ -109,7 +110,12 @@ describe("picnic-client session persistence", () => {
 
       await expect(initializePicnicClient()).resolves.toBeUndefined()
       expect(() => getPicnicClient()).not.toThrow()
-      expect(fs.writeFile).not.toHaveBeenCalled()
+      // The device-id resolver may persist a generated id, but no session
+      // should be written while 2FA is still pending.
+      expect(fs.writeFile).not.toHaveBeenCalledWith(
+        "picnic-session.json",
+        expect.anything(),
+      )
     })
 
     it("should keep running when login throws a TOTP wording variant", async () => {
@@ -120,7 +126,10 @@ describe("picnic-client session persistence", () => {
 
       await expect(initializePicnicClient()).resolves.toBeUndefined()
       expect(() => getPicnicClient()).not.toThrow()
-      expect(fs.writeFile).not.toHaveBeenCalled()
+      expect(fs.writeFile).not.toHaveBeenCalledWith(
+        "picnic-session.json",
+        expect.anything(),
+      )
     })
 
     it("should keep running when login throws a structured 2FA error", async () => {
@@ -131,7 +140,10 @@ describe("picnic-client session persistence", () => {
 
       await expect(initializePicnicClient()).resolves.toBeUndefined()
       expect(() => getPicnicClient()).not.toThrow()
-      expect(fs.writeFile).not.toHaveBeenCalled()
+      expect(fs.writeFile).not.toHaveBeenCalledWith(
+        "picnic-session.json",
+        expect.anything(),
+      )
     })
 
     it("should not re-initialize if already initialized", async () => {


### PR DESCRIPTION
Follow-up to #40 (closed as superseded by #46) and #39, implementing the one piece @ivo-toby suggested revisiting separately: the auto-generated, persisted device-id fallback.

## Why
#46 wired `PICNIC_DEVICE_ID` / `PICNIC_AGENT` through to the client. But when `PICNIC_DEVICE_ID` is not set, `deviceId` is `undefined`, so picnic-api falls back to its shared default device id. That means every unconfigured install still sends the same `x-picnic-did` — the correlation/blocking concern from #39 remains for anyone who does not manually set an id.

## What
- New `resolveDeviceId()` (`src/utils/device-id.ts`):
  1. returns `PICNIC_DEVICE_ID` when set;
  2. otherwise reads a persisted id from `PICNIC_DEVICE_FILE`;
  3. otherwise generates a random 16-char uppercase hex id and persists it for reuse.
- New `PICNIC_DEVICE_FILE` config (default `~/.picnic-device.json`), mirroring the existing `PICNIC_SESSION_FILE` pattern.
- `initializePicnicClient` passes the resolved id instead of the possibly-undefined `PICNIC_DEVICE_ID`.

## Compatibility
Fully backwards compatible: setting `PICNIC_DEVICE_ID` keeps current behaviour. Without it, each install now gets a stable, unique per-install id instead of the shared default. `typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)