### PR TITLE
[codex] add weekly promotions tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+.worktrees/
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/

--- a/PICNIC_TOOLS.md
+++ b/PICNIC_TOOLS.md
@@ -33,6 +33,19 @@ Search for products in Picnic.
 **Parameters:**
 
 - `query` (string): Search query for products
+- `limit` (number, optional): Maximum number of results to return (1-20, default: 5)
+- `offset` (number, optional): Number of results to skip for pagination (default: 0)
+
+#### `picnic_get_promotions`
+
+Get Picnic's current weekly promotions/deals from the app's "Alle acties" page.
+
+**Parameters:**
+
+- `limit` (number, optional): Maximum number of promotions to return (1-100, default: 25)
+- `offset` (number, optional): Number of promotions to skip for pagination (default: 0)
+
+**Returns:** Promoted products with product ID, promotion ID, name, current price, unit, promotion label, original price when shown, image ID, and pagination metadata.
 
 #### `picnic_get_suggestions`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MCP Picnic is a bridge between AI assistants (like Claude, ChatGPT, or other MCP
 ### 🤖 AI-Powered Shopping Tools
 
 - **Product Search**: Find any product in Picnic's catalog
+- **Weekly Promotions**: Fetch current Picnic deals from the app's "Alle acties" page
 - **Cart Management**: Add, remove, and modify items in your shopping cart
 - **Order Tracking**: Monitor delivery status and driver location
 - **Account Management**: Access your profile, payment methods, and order history
@@ -551,6 +552,7 @@ The server provides comprehensive access to Picnic's functionality through 30+ s
 ### Product Discovery & Search
 
 - **`picnic_search`** - Search for products by name or keywords
+- **`picnic_get_promotions`** - Get current weekly promotions/deals with prices and labels
 - **`picnic_get_suggestions`** - Get product suggestions based on query
 - **`picnic_get_product_details`** - Get detailed information about a specific product
 - **`picnic_get_image`** - Get product images in various sizes (tiny to extra-large)

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -88,6 +88,106 @@ function filterCartData(cart: unknown) {
   }
 }
 
+type UnknownRecord = Record<string, unknown>
+
+interface PicnicPromotionProduct {
+  product_id: string
+  promotion_id: string
+  name: string
+  price: number
+  unit?: string
+  promotion_label?: string
+  original_price?: number
+  image_id?: string
+  max_count?: number
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+function getRecordProperty(record: UnknownRecord, key: string): UnknownRecord | null {
+  const value = record[key]
+  return isRecord(value) ? value : null
+}
+
+function getPromotionContext(tile: UnknownRecord): UnknownRecord | null {
+  const analytics = getRecordProperty(tile, "analytics")
+  const contexts = analytics?.contexts
+  if (!Array.isArray(contexts)) return null
+
+  for (const context of contexts) {
+    if (!isRecord(context)) continue
+    const data = getRecordProperty(context, "data")
+    if (typeof data?.promotion_id === "string") return data
+  }
+
+  return null
+}
+
+function toPromotionProduct(tile: UnknownRecord): PicnicPromotionProduct | null {
+  const content = getRecordProperty(tile, "content")
+  const sellingUnit = content ? getRecordProperty(content, "sellingUnit") : null
+  const promotion = getPromotionContext(tile)
+
+  if (!sellingUnit || !promotion) return null
+  if (typeof sellingUnit.id !== "string" || typeof sellingUnit.name !== "string") return null
+  if (typeof promotion.promotion_id !== "string") return null
+
+  const price =
+    typeof promotion.price === "number"
+      ? promotion.price
+      : typeof sellingUnit.display_price === "number"
+        ? sellingUnit.display_price
+        : null
+  if (price === null) return null
+
+  return {
+    product_id: sellingUnit.id,
+    promotion_id: promotion.promotion_id,
+    name: sellingUnit.name,
+    price,
+    ...(typeof sellingUnit.unit_quantity === "string" && { unit: sellingUnit.unit_quantity }),
+    ...(typeof promotion.promotion_label === "string" && {
+      promotion_label: promotion.promotion_label,
+    }),
+    ...(typeof promotion.strikethrough_price === "number" &&
+      promotion.show_strikethrough_price !== false && {
+        original_price: promotion.strikethrough_price,
+      }),
+    ...(typeof sellingUnit.image_id === "string" && { image_id: sellingUnit.image_id }),
+    ...(typeof sellingUnit.max_count === "number" && { max_count: sellingUnit.max_count }),
+  }
+}
+
+function extractPromotionsFromPage(page: unknown): PicnicPromotionProduct[] {
+  const promotions: PicnicPromotionProduct[] = []
+  const seen = new Set<string>()
+
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child)
+      return
+    }
+
+    if (!isRecord(node)) return
+
+    const promotion = toPromotionProduct(node)
+    if (promotion) {
+      const key = `${promotion.product_id}:${promotion.promotion_id}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        promotions.push(promotion)
+      }
+    }
+
+    for (const value of Object.values(node)) visit(value)
+  }
+
+  visit(page)
+  return promotions
+}
+
 // Search products tool
 const searchInputSchema = z.object({
   query: z.string().describe("Search query for products"),
@@ -137,6 +237,60 @@ toolRegistry.register({
         returned: filteredResults.length,
         total: allResults.length,
         hasMore: startIndex + limit < allResults.length,
+      },
+    }
+  },
+})
+
+// Weekly promotions/deals tool
+const promotionsInputSchema = z.object({
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .default(25)
+    .describe("Maximum number of promotions to return (1-100, default: 25)"),
+  offset: z
+    .number()
+    .min(0)
+    .default(0)
+    .describe("Number of promotions to skip for pagination (default: 0)"),
+})
+
+toolRegistry.register({
+  name: "picnic_get_promotions",
+  description:
+    "Get Picnic's current weekly promotions/deals from the app's 'Alle acties' page. " +
+    "Returns promoted products with current price, promotion label, original price when shown, " +
+    "and pagination.",
+  inputSchema: promotionsInputSchema,
+  handler: async (args) => {
+    await ensureClientInitialized()
+    const client = getPicnicClient()
+    const page = await client.sendRequest(
+      "GET",
+      "/pages/promo-page-all-promos-redirect",
+      null,
+      true,
+    )
+    const allPromotions = extractPromotionsFromPage(page)
+
+    const startIndex = args.offset ?? 0
+    const limit = args.limit ?? 25
+    const promotions = allPromotions.slice(startIndex, startIndex + limit)
+
+    return {
+      source: {
+        pageId: "promo-page-all-promos-redirect",
+        endpoint: "/pages/promo-page-all-promos-redirect",
+      },
+      promotions,
+      pagination: {
+        offset: startIndex,
+        limit,
+        returned: promotions.length,
+        total: allPromotions.length,
+        hasMore: startIndex + limit < allPromotions.length,
       },
     }
   },

--- a/test/unit/tools/picnic-promotions-tools.test.ts
+++ b/test/unit/tools/picnic-promotions-tools.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ToolResult } from "../../../src/tools/registry.js"
+
+const mocks = vi.hoisted(() => ({
+  initializePicnicClient: vi.fn(),
+  sendRequest: vi.fn(),
+  verifyPicnic2FACode: vi.fn(),
+}))
+
+vi.mock("../../../src/utils/picnic-client.js", () => ({
+  getPicnicClient: () => ({
+    sendRequest: mocks.sendRequest,
+  }),
+  initializePicnicClient: mocks.initializePicnicClient,
+  saveSession: vi.fn(),
+  verifyPicnic2FACode: mocks.verifyPicnic2FACode,
+}))
+
+function parseToolResult(result: ToolResult) {
+  return JSON.parse(result.content[0].text ?? "")
+}
+
+function promoTile({
+  productId,
+  promotionId,
+  name,
+  label,
+  price,
+  originalPrice,
+}: {
+  productId: string
+  promotionId: string
+  name: string
+  label: string
+  price: number
+  originalPrice?: number
+}) {
+  return {
+    type: "PML",
+    id: `selling-unit-${productId}-tile`,
+    analytics: {
+      contexts: [
+        {
+          data: { product_id: productId },
+          schema: "iglu:tech.picnic.snowplow.analytics/product/jsonschema/1-0-0",
+        },
+        {
+          data: {
+            promotion_id: promotionId,
+            promotion_label: label,
+            price,
+            ...(originalPrice !== undefined && {
+              strikethrough_price: originalPrice,
+              show_strikethrough_price: true,
+            }),
+          },
+          schema: "iglu:tech.picnic.snowplow.analytics/promotion/jsonschema/1-1-0",
+        },
+      ],
+    },
+    content: {
+      type: "SELLING_UNIT_TILE",
+      sellingUnit: {
+        id: productId,
+        display_price: price,
+        image_id: `image-${productId}`,
+        max_count: 12,
+        name,
+        unit_quantity: "1 stuk",
+      },
+    },
+  }
+}
+
+function regularTile() {
+  return {
+    type: "PML",
+    id: "selling-unit-s999-tile",
+    analytics: { contexts: [{ data: { product_id: "s999" } }] },
+    content: {
+      type: "SELLING_UNIT_TILE",
+      sellingUnit: {
+        id: "s999",
+        display_price: 399,
+        name: "Regular product",
+        unit_quantity: "1 stuk",
+      },
+    },
+  }
+}
+
+async function loadTools() {
+  vi.resetModules()
+  const { toolRegistry } = await import("../../../src/tools/registry.js")
+  await import("../../../src/tools/picnic-tools.js")
+  return toolRegistry
+}
+
+describe("promotions tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("fetches weekly Picnic promotions from the all-promos page", async () => {
+    const firstTile = promoTile({
+      productId: "s100",
+      promotionId: "promo-1",
+      name: "Discount tomatoes",
+      label: "nu €1.99",
+      price: 199,
+      originalPrice: 249,
+    })
+    mocks.sendRequest.mockResolvedValue({
+      layout: {
+        body: {
+          children: [
+            firstTile,
+            regularTile(),
+            [
+              promoTile({
+                productId: "s200",
+                promotionId: "promo-2",
+                name: "Bonus pasta",
+                label: "1+1 gratis",
+                price: 239,
+              }),
+              firstTile,
+            ],
+          ],
+        },
+      },
+    })
+
+    const toolRegistry = await loadTools()
+    const result = await toolRegistry.executeTool("picnic_get_promotions", {})
+    const payload = parseToolResult(result)
+
+    expect(mocks.sendRequest).toHaveBeenCalledWith(
+      "GET",
+      "/pages/promo-page-all-promos-redirect",
+      null,
+      true,
+    )
+    expect(payload.promotions).toEqual([
+      {
+        product_id: "s100",
+        promotion_id: "promo-1",
+        name: "Discount tomatoes",
+        price: 199,
+        unit: "1 stuk",
+        promotion_label: "nu €1.99",
+        original_price: 249,
+        image_id: "image-s100",
+        max_count: 12,
+      },
+      {
+        product_id: "s200",
+        promotion_id: "promo-2",
+        name: "Bonus pasta",
+        price: 239,
+        unit: "1 stuk",
+        promotion_label: "1+1 gratis",
+        image_id: "image-s200",
+        max_count: 12,
+      },
+    ])
+    expect(payload.pagination).toEqual({
+      offset: 0,
+      limit: 25,
+      returned: 2,
+      total: 2,
+      hasMore: false,
+    })
+  })
+
+  it("paginates promotions after deduplicating repeated tiles", async () => {
+    mocks.sendRequest.mockResolvedValue({
+      layout: {
+        body: [
+          promoTile({
+            productId: "s100",
+            promotionId: "promo-1",
+            name: "Discount tomatoes",
+            label: "nu €1.99",
+            price: 199,
+          }),
+          promoTile({
+            productId: "s200",
+            promotionId: "promo-2",
+            name: "Bonus pasta",
+            label: "1+1 gratis",
+            price: 239,
+          }),
+          promoTile({
+            productId: "s300",
+            promotionId: "promo-3",
+            name: "Deal soap",
+            label: "2 voor €5",
+            price: 279,
+          }),
+        ],
+      },
+    })
+
+    const toolRegistry = await loadTools()
+    const result = await toolRegistry.executeTool("picnic_get_promotions", {
+      offset: 1,
+      limit: 1,
+    })
+    const payload = parseToolResult(result)
+
+    expect(payload.promotions).toEqual([
+      expect.objectContaining({
+        product_id: "s200",
+        promotion_id: "promo-2",
+      }),
+    ])
+    expect(payload.pagination).toEqual({
+      offset: 1,
+      limit: 1,
+      returned: 1,
+      total: 3,
+      hasMore: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `picnic_get_promotions` for Picnic's current weekly deals using `GET /pages/promo-page-all-promos-redirect` from the app's "Alle acties" page.
- Extracts promoted selling-unit tiles with promotion analytics, deduplicates repeated product/promotion pairs, and returns paginated product/deal data.
- Documents the new tool and ignores repo-local `.worktrees/` directories.

## Research
Issue #52 asked whether Picnic exposes weekly promotions. I did not find a documented first-class wrapper method in `picnic-api`, but the upstream package supports raw `sendRequest`, and a read-only authenticated probe confirmed the app page endpoint above contains current promoted products with `promotion_id`, `promotion_label`, current price, and strikethrough price where shown.

Closes #52

## Validation
- `npx prettier --check src/tools/picnic-tools.ts test/unit/tools/picnic-promotions-tools.test.ts PICNIC_TOOLS.md --ignore-unknown`
- `npm run typecheck`
- `npm run lint`
- `npm test` (18 files, 246 tests)
- `npm run build`