### PR TITLE
fix(cart): make failed cart mutations safe to act on

### DIFF
--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -39,6 +39,37 @@ async function ensureClientInitialized() {
   }
 }
 
+/**
+ * Runs a cart mutation, converting failures into an explicitly ambiguous error.
+ *
+ * Picnic applies the mutation and renders the updated cart in the same request, so a
+ * non-2xx response does not mean the write was rejected — it may already have landed and
+ * only the render failed. A caller that reads such an error as "nothing happened" will
+ * retry, and each retry applies the change again. Say so instead of reporting a clean
+ * failure, and point the caller at a read rather than a retry.
+ */
+async function mutateCart<T>(action: string, mutation: () => Promise<T>): Promise<T> {
+  try {
+    return await mutation()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `${action} failed: ${message}. The cart may still have been modified — ` +
+        `call picnic_get_cart to check the current contents before retrying, ` +
+        `because retrying can apply the change a second time.`,
+    )
+  }
+}
+
+// Annotations shared by every tool that mutates cart contents. Tells the calling model the
+// operation is not safe to blindly retry (see mutateCart above).
+const CART_MUTATION_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+} as const
+
 // Helper function to filter cart data for LLM consumption
 function filterCartData(cart: unknown) {
   if (!cart || typeof cart !== "object") return cart
@@ -645,19 +676,18 @@ toolRegistry.register({
   name: "picnic_add_recipe_to_cart",
   description:
     "Add a recipe's ingredients to the shopping cart by assigning the recipe (selling group) " +
-    "to the basket. Optionally set the number of portions.",
+    "to the basket. Optionally set the number of portions. If this fails, call picnic_get_cart " +
+    "to check whether the ingredients landed before retrying.",
   inputSchema: addRecipeToCartInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
     const recipeId = await resolveRecipeId(args.recipe_url_or_id)
     const payload: { selling_group_id: string; portions?: number } = { selling_group_id: recipeId }
     if (args.portions !== undefined) payload.portions = args.portions
-    await client.sendRequest(
-      "POST",
-      "/pages/task/assign-selling-group-to-basket",
-      { payload },
-      true,
+    await mutateCart("Adding the recipe to the cart", () =>
+      client.sendRequest("POST", "/pages/task/assign-selling-group-to-basket", { payload }, true),
     )
     return {
       message: "Recipe added to cart",
@@ -674,15 +704,18 @@ toolRegistry.register({
     "Remove a recipe (selling group) from the basket, undoing picnic_add_recipe_to_cart. " +
     "Removes only that recipe's ingredients, leaving the rest of the cart untouched.",
   inputSchema: recipeRefInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
     const recipeId = await resolveRecipeId(args.recipe_url_or_id)
-    await client.sendRequest(
-      "POST",
-      "/pages/task/remove-selling-group-from-basket",
-      { payload: { selling_group_id: recipeId } },
-      true,
+    await mutateCart("Removing the recipe from the cart", () =>
+      client.sendRequest(
+        "POST",
+        "/pages/task/remove-selling-group-from-basket",
+        { payload: { selling_group_id: recipeId } },
+        true,
+      ),
     )
     return { message: "Recipe removed from cart", recipeId }
   },
@@ -832,12 +865,17 @@ const addToCartInputSchema = z.object({
 
 toolRegistry.register({
   name: "picnic_add_to_cart",
-  description: "Add a product to the shopping cart",
+  description:
+    "Add a product to the shopping cart. Not idempotent: each call adds another `count` " +
+    "items. If this fails, call picnic_get_cart to check whether the add landed before retrying.",
   inputSchema: addToCartInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    const cart = await client.cart.addProductToCart(args.productId, args.count)
+    const cart = await mutateCart(`Adding ${args.count} item(s) to cart`, () =>
+      client.cart.addProductToCart(args.productId, args.count),
+    )
     return {
       message: `Added ${args.count} item(s) to cart`,
       cart: filterCartData(cart),
@@ -853,12 +891,18 @@ const removeFromCartInputSchema = z.object({
 
 toolRegistry.register({
   name: "picnic_remove_from_cart",
-  description: "Remove a product from the shopping cart",
+  description:
+    "Remove a product from the shopping cart. Not idempotent: each call removes another " +
+    "`count` items. If this fails, call picnic_get_cart to check whether the removal landed " +
+    "before retrying.",
   inputSchema: removeFromCartInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    const cart = await client.cart.removeProductFromCart(args.productId, args.count)
+    const cart = await mutateCart(`Removing ${args.count} item(s) from cart`, () =>
+      client.cart.removeProductFromCart(args.productId, args.count),
+    )
     return {
       message: `Removed ${args.count} item(s) from cart`,
       cart: filterCartData(cart),
@@ -871,10 +915,11 @@ toolRegistry.register({
   name: "picnic_clear_cart",
   description: "Clear all items from the shopping cart",
   inputSchema: z.object({}),
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async () => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    const cart = await client.cart.clearCart()
+    const cart = await mutateCart("Clearing the cart", () => client.cart.clearCart())
     return {
       message: "Shopping cart cleared",
       cart: filterCartData(cart),

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -88,6 +88,7 @@ function filterCartData(cart: unknown) {
         price?: number
         image_ids?: string[]
         max_count?: number
+        decorators?: Array<{ type?: string; quantity?: number }>
       }>
     }>
     total_count?: number
@@ -104,6 +105,10 @@ function filterCartData(cart: unknown) {
       name: article.name,
       unit: article.unit_quantity,
       price: article.price,
+      // How many of this article are in the cart. Picnic carries it in a QUANTITY decorator
+      // rather than a plain field; without it a caller cannot tell one unit from three, so it
+      // cannot check whether an ambiguous add actually landed (see mutateCart).
+      quantity: article.decorators?.find((d) => d.type === "QUANTITY")?.quantity ?? 1,
       ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
     })),
   }))

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,18 @@ import { z } from "zod"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { ToolError, ErrorCode, ErrorUtils } from "../types/errors.js"
 
+/**
+ * MCP tool annotations. Hints for the calling model about a tool's side effects —
+ * most importantly whether it is safe to retry after an ambiguous failure.
+ */
+export interface ToolAnnotations {
+  title?: string
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+  openWorldHint?: boolean
+}
+
 export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   name: string
   description: string
@@ -9,6 +21,7 @@ export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   outputSchema?: z.ZodSchema<TOutput>
   handler: (args: TInput) => Promise<TOutput>
   prompts?: string[]
+  annotations?: ToolAnnotations
 }
 
 export interface ToolResult {
@@ -29,6 +42,7 @@ interface StoredToolDefinition {
   outputSchema?: z.ZodSchema<unknown>
   handler: (args: unknown) => Promise<unknown>
   prompts?: string[]
+  annotations?: ToolAnnotations
 }
 
 class ToolRegistry {
@@ -45,6 +59,7 @@ class ToolRegistry {
         name: tool.name,
         description: tool.description,
         inputSchema: zodToJsonSchema(tool.inputSchema),
+        ...(tool.annotations && { annotations: tool.annotations }),
       }
     }
     return definitions
@@ -55,6 +70,7 @@ class ToolRegistry {
       name: tool.name,
       description: tool.description,
       inputSchema: zodToJsonSchema(tool.inputSchema),
+      ...(tool.annotations && { annotations: tool.annotations }),
     }))
   }
 

--- a/test/unit/tools/picnic-cart-tools.test.ts
+++ b/test/unit/tools/picnic-cart-tools.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ToolResult } from "../../../src/tools/registry.js"
+
+const mocks = vi.hoisted(() => ({
+  addProductToCart: vi.fn(),
+  removeProductFromCart: vi.fn(),
+  clearCart: vi.fn(),
+  getCart: vi.fn(),
+  initializePicnicClient: vi.fn(),
+}))
+
+vi.mock("../../../src/utils/picnic-client.js", () => ({
+  getPicnicClient: () => ({
+    cart: {
+      addProductToCart: mocks.addProductToCart,
+      removeProductFromCart: mocks.removeProductFromCart,
+      clearCart: mocks.clearCart,
+      getCart: mocks.getCart,
+    },
+    sendRequest: vi.fn(),
+  }),
+  initializePicnicClient: mocks.initializePicnicClient,
+  saveSession: vi.fn(),
+  verifyPicnic2FACode: vi.fn(),
+}))
+
+function parseToolResult(result: ToolResult) {
+  return JSON.parse(result.content[0].text ?? "")
+}
+
+const emptyCart = { type: "ORDER", id: "cart-1", items: [], total_count: 0 }
+
+describe("picnic cart tools", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await import("../../../src/tools/picnic-tools.js")
+  })
+
+  describe("mutation failures", () => {
+    // Picnic applies the write and renders the cart in one request, so a failure does not
+    // mean the write was rejected. The error has to say so, or the caller retries and
+    // double-applies the change.
+    it("warns that the cart may have changed when add_to_cart fails", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.addProductToCart.mockRejectedValue(
+        new Error("Client version is required to preview the cart page"),
+      )
+
+      await expect(
+        toolRegistry.executeTool("picnic_add_to_cart", { productId: "s1032332", count: 1 }),
+      ).rejects.toThrow(/cart may still have been modified/i)
+    })
+
+    it("points the caller at picnic_get_cart rather than a retry", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.removeProductFromCart.mockRejectedValue(new Error("boom"))
+
+      await expect(
+        toolRegistry.executeTool("picnic_remove_from_cart", { productId: "s1", count: 1 }),
+      ).rejects.toThrow(/picnic_get_cart/)
+    })
+
+    it("preserves the upstream error message", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.clearCart.mockRejectedValue(new Error("upstream detail"))
+
+      await expect(toolRegistry.executeTool("picnic_clear_cart", {})).rejects.toThrow(
+        /upstream detail/,
+      )
+    })
+  })
+
+  describe("successful mutations", () => {
+    it("returns the filtered cart on success", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.addProductToCart.mockResolvedValue(emptyCart)
+
+      const result = await toolRegistry.executeTool("picnic_add_to_cart", {
+        productId: "s1032332",
+        count: 2,
+      })
+
+      expect(mocks.addProductToCart).toHaveBeenCalledWith("s1032332", 2)
+      expect(parseToolResult(result).message).toBe("Added 2 item(s) to cart")
+    })
+
+    it("does not retry the mutation itself", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.addProductToCart.mockRejectedValue(new Error("nope"))
+
+      await expect(
+        toolRegistry.executeTool("picnic_add_to_cart", { productId: "s1", count: 1 }),
+      ).rejects.toThrow()
+      expect(mocks.addProductToCart).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("annotations", () => {
+    it("marks cart mutations as non-idempotent and destructive", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      const list = toolRegistry.getToolsList() as Array<{
+        name: string
+        annotations?: Record<string, boolean>
+      }>
+
+      for (const name of [
+        "picnic_add_to_cart",
+        "picnic_remove_from_cart",
+        "picnic_clear_cart",
+        "picnic_add_recipe_to_cart",
+        "picnic_remove_recipe_from_cart",
+      ]) {
+        const tool = list.find((t) => t.name === name)
+        expect(tool, `${name} should be registered`).toBeDefined()
+        expect(tool?.annotations, `${name} should carry annotations`).toMatchObject({
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+        })
+      }
+    })
+
+    it("leaves read-only tools unannotated", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      const list = toolRegistry.getToolsList() as Array<{
+        name: string
+        annotations?: Record<string, boolean>
+      }>
+
+      expect(list.find((t) => t.name === "picnic_get_cart")?.annotations).toBeUndefined()
+    })
+  })
+})

--- a/test/unit/tools/picnic-cart-tools.test.ts
+++ b/test/unit/tools/picnic-cart-tools.test.ts
@@ -131,3 +131,55 @@ describe("picnic cart tools", () => {
     })
   })
 })
+
+describe("picnic_get_cart quantities", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await import("../../../src/tools/picnic-tools.js")
+  })
+
+  // Without this the caller cannot verify whether an ambiguous add landed once or twice,
+  // which is exactly what the mutation error message tells it to go and check.
+  it("surfaces the QUANTITY decorator as a quantity field", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      type: "ORDER",
+      id: "shopping_cart",
+      total_count: 2,
+      items: [
+        {
+          type: "ORDER_LINE",
+          id: "1871",
+          price: 510,
+          items: [
+            {
+              id: "s1032332",
+              name: "Frosch Cremeseife",
+              unit_quantity: "500ml",
+              price: 255,
+              decorators: [
+                { type: "QUANTITY", quantity: 2 },
+                { type: "UNIT_QUANTITY", unit_quantity_text: "500ml" },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0].articles[0].quantity).toBe(2)
+  })
+
+  it("defaults to 1 when no QUANTITY decorator is present", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      type: "ORDER",
+      id: "shopping_cart",
+      items: [{ id: "1", price: 255, items: [{ id: "s1", name: "x", price: 255 }] }],
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0].articles[0].quantity).toBe(1)
+  })
+})


### PR DESCRIPTION
A failed cart mutation is indistinguishable from a no-op, so the caller retries and the
change is applied twice. Observed in production: two `picnic_add_to_cart` calls both
returned errors, and the Picnic app then showed **two** units of the product.

## Problem

Picnic applies the mutation and renders the updated cart in the **same** request. A non-2xx
response therefore does not mean the write was rejected — it may have landed with only the
render failing. `picnic_add_to_cart` surfaced that as a plain failure, which reads as
"nothing happened" and invites a retry. Every retry adds another unit.

Three things compound it:

1. The error text gives no way to tell "not written" from "written, display failed".
2. No tool declared MCP annotations, so a client had no signal that these tools are unsafe
   to auto-retry. The registry had no annotation support at all.
3. `picnic_get_cart` did not report quantities. Picnic carries the count in a `QUANTITY`
   decorator, which the cart filter discarded, so one unit and three units rendered
   identically. A caller could not check the result even if it thought to.

(3) is what makes this unrecoverable rather than merely annoying: there was no read that
could answer "did my add land?"

## Reproduce

Force any failure out of the cart render — e.g. run against `picnic-api@4.1.0`, whose cart
calls omit `x-picnic-agent` and get `Client version is required to preview the cart page`
(fixed upstream in #46; the version bump is already on `main`):

```
picnic_add_to_cart("s1032332", 1)   -> error
picnic_add_to_cart("s1032332", 1)   -> same error
```

Then open the Picnic app: the cart holds 2 units. `picnic_get_cart` before this PR shows the
product but no quantity, so the duplication is invisible from the tool surface.

## Fix

- `mutateCart()` wraps the five cart-mutating tools and rewrites failures to state that the
  cart may already have changed, directing the caller to `picnic_get_cart` instead of a
  retry. The upstream message is preserved. The write and the render are one server-side
  request, so the client cannot decouple them — it can only stop reporting an ambiguous
  outcome as a clean failure.
- Registry gains `annotations` support; the five mutating tools declare
  `destructiveHint: true`, `idempotentHint: false`, `readOnlyHint: false`. Tool descriptions
  state the non-idempotence.
- `picnic_get_cart` returns `quantity` per article, read from the `QUANTITY` decorator,
  defaulting to 1 when absent — so a caller can finally check whether an add landed once or
  twice.

No behaviour change on success.

## Testing

`npm test` — 255 passing (up from 246); 9 new tests in `test/unit/tools/picnic-cart-tools.test.ts`
cover the ambiguous-failure message, the annotation set, that a failed mutation is not retried
internally, and quantity extraction. `npm run typecheck`, `npm run lint`, `npm run build` clean.

Driven over stdio against a live Picnic account (DE) with the built server: `tools/list`
reports the annotations on exactly the five mutating tools, and `picnic_get_cart` renders
quantities correctly, including a line genuinely holding 2 units.

Split out of this PR: #57 (an unrelated stale-client-version fix on the 2FA path) and #59
(surfacing promotion and recipe decorators, which stacks on this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




