### PR TITLE
fix(2fa): source client version headers from the client instead of a stale copy

### DIFF
--- a/src/utils/picnic-client.ts
+++ b/src/utils/picnic-client.ts
@@ -5,19 +5,23 @@ import { resolveDeviceId } from "./device-id.js"
 
 // Singleton instance for caching
 let picnicClientInstance: InstanceType<typeof PicnicClient> | null = null
-const DEFAULT_PICNIC_AGENT = "30100;1.15.232-15154"
 
 type PicnicCountryCode = "NL" | "DE" | "FR"
 type PicnicClientOptions = NonNullable<ConstructorParameters<typeof PicnicClient>[0]> &
   Record<string, unknown>
 
-function buildPicnicHeaders(authKey: string | null, deviceId: string): HeadersInit {
+/**
+ * Headers for the hand-rolled 2FA verify request.
+ *
+ * Sourced from the client instance rather than redeclared here: Picnic gates several
+ * endpoints on the `x-picnic-agent` client version, so a local copy that drifts behind
+ * picnic-api's default silently breaks those calls. Reading the live values keeps this
+ * request identical to every request the library sends.
+ */
+function buildPicnicHeaders(client: InstanceType<typeof PicnicClient>): HeadersInit {
   return {
-    "User-Agent": "okhttp/3.12.2",
-    "Content-Type": "application/json; charset=UTF-8",
-    ...(authKey && { "x-picnic-auth": authKey }),
-    "x-picnic-agent": config.PICNIC_AGENT ?? DEFAULT_PICNIC_AGENT,
-    "x-picnic-did": deviceId,
+    ...client.baseHeaders,
+    ...client.picnicHeaders,
   }
 }
 
@@ -86,12 +90,11 @@ export async function verifyPicnic2FACode(
   const client = getPicnicClient()
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
-  const deviceId = await resolveDeviceId()
 
   try {
     const response = await fetch(`${client.url}/user/2fa/verify`, {
       method: "POST",
-      headers: new Headers(buildPicnicHeaders(client.authKey, deviceId)),
+      headers: new Headers(buildPicnicHeaders(client)),
       body: JSON.stringify({ otp: code }),
       signal: controller.signal,
     })


### PR DESCRIPTION
## Problem

`picnic_verify_2fa_code` uses a hand-rolled `fetch()` instead of the library, and built its
headers from a local copy of the client version:

```ts
// src/utils/picnic-client.ts
const DEFAULT_PICNIC_AGENT = "30100;1.15.232-15154"
...
"x-picnic-agent": config.PICNIC_AGENT ?? DEFAULT_PICNIC_AGENT,
"User-Agent": "okhttp/3.12.2",
```

`picnic-api@4.5.0` defaults to `30100;1.228.1-15480;` and `okhttp/4.9.0`. #46 added the
`agent` / `deviceId` options and passes them to the client, but this fallback was left
behind, so with `PICNIC_AGENT` unset the library sends the current client version while 2FA
verification sends one many releases old.

Picnic gates endpoints on that header, returning `Client version is required to ...`. Any
such rejection would land only on 2FA verification — the one call in the codebase that does
not go through the library, and so the hardest to attribute.

## Reproduce

With `PICNIC_AGENT` unset, log the outgoing headers for any library call and for
`picnic_verify_2fa_code`:

- library call → `x-picnic-agent: 30100;1.228.1-15480;`
- 2FA verify → `x-picnic-agent: 30100;1.15.232-15154`

## Fix

Build the headers from the client instance (`client.baseHeaders` / `client.picnicHeaders`,
both public typed getters on `HttpClient`) so the request is identical to every other
request and cannot drift again. This also picks up `Accept-Language`, which the local copy
omitted. `DEFAULT_PICNIC_AGENT` is deleted; `PICNIC_AGENT` still overrides via the client.

## Notes

Open #33 removes this `fetch()` entirely in favour of `client.auth.verify2FACode(...)`,
which is the better end state and supersedes this. It targets `4.3.0` and also drops `FR`
support, so it needs a rebase. This change is compatible either way — if #33 lands,
`buildPicnicHeaders` goes away with it.

## Testing

`npm test` (246 passing), `npm run typecheck`, `npm run lint`, `npm run build` — all clean.
Not exercised against a live 2FA challenge; the account under test had a valid session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
