### PR TITLE
fix(image): make picnic_get_image actually return an image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "picnic-api": "^4.5.0",
+        "picnic-api": "^4.6.0",
         "undici": "^6.21.0",
         "zod": "^3.24.4",
         "zod-to-json-schema": "^3.25.1"
@@ -8078,9 +8078,9 @@
       }
     },
     "node_modules/picnic-api": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.5.0.tgz",
-      "integrity": "sha512-Yyi9n9Ek5xb8+qNEmvo0QjnEn0/wqimO8x0tOX8hS5iu9GAO0kWtKWO7JX0ouCtevzzFwpaEu6nFESeUyMrC3A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.6.0.tgz",
+      "integrity": "sha512-9knSdRcznUNeTlsAMIef7k+amIOqTWVezTu2YgNl6a8wsyQFDxkF659QxWHn9Yy/wkZi12xCNi7Pu0UN1zltHw==",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.3.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "picnic-api": "^4.5.0",
+    "picnic-api": "^4.6.0",
     "undici": "^6.21.0",
     "zod": "^3.24.4",
     "zod-to-json-schema": "^3.25.1"

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { toolRegistry } from "./registry.js"
+import { toolRegistry, mcpContent } from "./registry.js"
 import {
   getPicnicClient,
   initializePicnicClient,
@@ -370,17 +370,21 @@ const imageInputSchema = z.object({
 
 toolRegistry.register({
   name: "picnic_get_image",
-  description: "Get image data for a product using the image ID and size",
+  description:
+    "Get a product image by image ID and size. Returns the image itself as MCP image content.",
   inputSchema: imageInputSchema,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
     const image = await client.catalog.getImage(args.imageId, args.size)
-    return {
-      imageId: args.imageId,
-      size: args.size,
-      image,
-    }
+    // Picnic serves these as PNG (/static/images/<id>/<size>.png).
+    return mcpContent([
+      {
+        type: "image",
+        data: Buffer.from(image).toString("base64"),
+        mimeType: "image/png",
+      },
+    ])
   },
 })
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -21,6 +21,33 @@ export interface ToolResult {
   isError?: boolean
 }
 
+/**
+ * Marker for handlers that emit MCP content blocks directly.
+ *
+ * Every other handler return value is JSON-serialized into a single `text` block, which is
+ * correct for data but destroys binary payloads — an ArrayBuffer stringifies to `{}`. A
+ * handler wrapping its blocks in `mcpContent()` has them passed through to the client
+ * untouched, so an image arrives as renderable image content rather than a JSON string.
+ */
+const MCP_CONTENT = Symbol("mcpContent")
+
+interface McpContentResult {
+  [MCP_CONTENT]: true
+  content: ToolResult["content"]
+}
+
+export function mcpContent(content: ToolResult["content"]): McpContentResult {
+  return { [MCP_CONTENT]: true, content }
+}
+
+function isMcpContent(value: unknown): value is McpContentResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[MCP_CONTENT] === true
+  )
+}
+
 // Type-erased version for storage
 interface StoredToolDefinition {
   name: string
@@ -107,6 +134,12 @@ class ToolRegistry {
             args: validatedArgs,
           },
         )
+      }
+
+      // Content blocks are already the wire format, so they skip output validation and
+      // JSON formatting rather than being serialized like a data payload.
+      if (isMcpContent(result)) {
+        return { content: result.content }
       }
 
       // Validate output if schema is provided

--- a/test/unit/tools/picnic-image-tools.test.ts
+++ b/test/unit/tools/picnic-image-tools.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getImage: vi.fn(),
+  search: vi.fn(),
+  initializePicnicClient: vi.fn(),
+}))
+
+vi.mock("../../../src/utils/picnic-client.js", () => ({
+  getPicnicClient: () => ({
+    catalog: { getImage: mocks.getImage, search: mocks.search },
+    sendRequest: vi.fn(),
+  }),
+  initializePicnicClient: mocks.initializePicnicClient,
+  saveSession: vi.fn(),
+  verifyPicnic2FACode: vi.fn(),
+}))
+
+// A one-pixel PNG, so the assertions run against a real binary payload rather than a string.
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+)
+
+describe("picnic_get_image", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await import("../../../src/tools/picnic-tools.js")
+  })
+
+  // The handler used to return the ArrayBuffer inside a plain object, which the registry
+  // JSON-serialized — and an ArrayBuffer stringifies to `{}`, so the image never arrived.
+  it("returns renderable image content rather than a JSON string", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getImage.mockResolvedValue(
+      PNG.buffer.slice(PNG.byteOffset, PNG.byteOffset + PNG.byteLength),
+    )
+
+    const result = await toolRegistry.executeTool("picnic_get_image", {
+      imageId: "abc",
+      size: "small",
+    })
+
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe("image")
+    expect(result.content[0].mimeType).toBe("image/png")
+    expect(result.content[0].data).toBe(PNG.toString("base64"))
+    expect(result.content[0].text).toBeUndefined()
+  })
+
+  it("round-trips the bytes unchanged", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getImage.mockResolvedValue(
+      PNG.buffer.slice(PNG.byteOffset, PNG.byteOffset + PNG.byteLength),
+    )
+
+    const result = await toolRegistry.executeTool("picnic_get_image", {
+      imageId: "abc",
+      size: "small",
+    })
+
+    expect(Buffer.from(result.content[0].data ?? "", "base64").equals(PNG)).toBe(true)
+  })
+
+  it("passes the requested id and size through", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getImage.mockResolvedValue(new ArrayBuffer(8))
+
+    await toolRegistry.executeTool("picnic_get_image", { imageId: "xyz", size: "large" })
+
+    expect(mocks.getImage).toHaveBeenCalledWith("xyz", "large")
+  })
+
+  it("still serializes ordinary object results as text", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.search.mockResolvedValue([{ id: "s1", name: "Bananen", display_price: 169 }])
+
+    const result = await toolRegistry.executeTool("picnic_search", { query: "x", limit: 1 })
+
+    expect(result.content[0].type).toBe("text")
+    expect(JSON.parse(result.content[0].text ?? "").results).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
`picnic_get_image` does not work on `main`. It fails, and if it did not fail it would still
return nothing usable. Two independent causes, one per commit.

## Problem 1 — the request URL is malformed

`catalog.getImage()` builds an **absolute** URL and passes it as the request path:

```js
const alternateRoute = this.http.url.split("/api/")[0]
return this.http.sendRequest("GET", `${alternateRoute}/static/images/${imageId}/${size}.png`, ...)
```

`picnic-api@4.5.0` unconditionally prefixes the path with the API base, producing
`https://storefront-prod.de…/api/15https://storefront-prod.de…/static/images/…`.

`4.6.0` fixes this in `http-client.js` by detecting absolute paths:

```js
const requestUrl = /^https?:\/\//.test(path) ? path : `${this.url}${path}`
```

So this half is a dependency bump, not a code change.

## Problem 2 — the payload is dropped

The handler returned the `ArrayBuffer` inside a plain object, and `ToolRegistry`
JSON-serializes every handler result into a single `text` block. An `ArrayBuffer`
stringifies to `{}`, so the image was discarded even on success:

```json
{ "imageId": "622a9caa…", "size": "small", "image": {} }
```

`ToolResult` already declared `type: "image"` with `data` / `mimeType`, but `executeTool`
had no path that could ever emit it.

## Reproduce

```
picnic_get_image({ imageId: "622a9caa9e420c4af672ba72d4aeda8dbff5938fecd33a529ec2ea72e6ead515", size: "small" })
```

- on `main` → HTTP 400, `Ambiguous URI empty segment`
- with only the `4.6.0` bump → succeeds, returns `"image": {}`
- with both commits → a `type: "image"` content block

## Fix

- Bump `picnic-api` to `^4.6.0`.
- Add `mcpContent()` to the registry: a handler wrapping its blocks in it has them passed
  through untouched instead of JSON-serialized. Marked with a `Symbol` so no ordinary
  return value can trip it, and it bypasses `outputSchema` validation since content blocks
  are the wire format rather than a data payload.
- `picnic_get_image` returns `{ type: "image", data: <base64>, mimeType: "image/png" }`.

Every other tool is untouched and still serializes to text — covered by a regression test.

## Testing

`npm test` — 250 passing (up from 246), 4 new tests covering the image content block, byte
round-tripping, argument pass-through, and the text-serialization regression guard.
`npm run typecheck`, `npm run lint`, `npm run build` clean.

Verified end to end against a live account (DE) over stdio: the tool returns one `image`
block, `mimeType: image/png`, 6475 bytes decoding to a valid PNG (`150 x 121, 8-bit
colormap`) — the product photo, rendering correctly.

## Relationship to #54

#54 found the same broken URL and fixed it by constructing the static URL by hand. That
workaround is no longer needed now that `4.6.0` fixes the root cause upstream, so this takes
the dependency bump instead. This PR also implements the registry change @ivo-toby asked for
in review on #54 — the P2 about returning real MCP image content — which #54 left open.
Credit to @axtg for finding the URL bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
