### PR TITLE
feat(cart): surface promotion label and originating recipe id

### DIFF
--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -39,6 +39,37 @@ async function ensureClientInitialized() {
   }
 }
 
+/**
+ * Runs a cart mutation, converting failures into an explicitly ambiguous error.
+ *
+ * Picnic applies the mutation and renders the updated cart in the same request, so a
+ * non-2xx response does not mean the write was rejected — it may already have landed and
+ * only the render failed. A caller that reads such an error as "nothing happened" will
+ * retry, and each retry applies the change again. Say so instead of reporting a clean
+ * failure, and point the caller at a read rather than a retry.
+ */
+async function mutateCart<T>(action: string, mutation: () => Promise<T>): Promise<T> {
+  try {
+    return await mutation()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `${action} failed: ${message}. The cart may still have been modified — ` +
+        `call picnic_get_cart to check the current contents before retrying, ` +
+        `because retrying can apply the change a second time.`,
+    )
+  }
+}
+
+// Annotations shared by every tool that mutates cart contents. Tells the calling model the
+// operation is not safe to blindly retry (see mutateCart above).
+const CART_MUTATION_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+} as const
+
 // Helper function to filter cart data for LLM consumption
 function filterCartData(cart: unknown) {
   if (!cart || typeof cart !== "object") return cart
@@ -645,19 +676,18 @@ toolRegistry.register({
   name: "picnic_add_recipe_to_cart",
   description:
     "Add a recipe's ingredients to the shopping cart by assigning the recipe (selling group) " +
-    "to the basket. Optionally set the number of portions.",
+    "to the basket. Optionally set the number of portions. If this fails, call picnic_get_cart " +
+    "to check whether the ingredients landed before retrying.",
   inputSchema: addRecipeToCartInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
     const recipeId = await resolveRecipeId(args.recipe_url_or_id)
     const payload: { selling_group_id: string; portions?: number } = { selling_group_id: recipeId }
     if (args.portions !== undefined) payload.portions = args.portions
-    await client.sendRequest(
-      "POST",
-      "/pages/task/assign-selling-group-to-basket",
-      { payload },
-      true,
+    await mutateCart("Adding the recipe to the cart", () =>
+      client.sendRequest("POST", "/pages/task/assign-selling-group-to-basket", { payload }, true),
     )
     return {
       message: "Recipe added to cart",
@@ -674,15 +704,18 @@ toolRegistry.register({
     "Remove a recipe (selling group) from the basket, undoing picnic_add_recipe_to_cart. " +
     "Removes only that recipe's ingredients, leaving the rest of the cart untouched.",
   inputSchema: recipeRefInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
     const recipeId = await resolveRecipeId(args.recipe_url_or_id)
-    await client.sendRequest(
-      "POST",
-      "/pages/task/remove-selling-group-from-basket",
-      { payload: { selling_group_id: recipeId } },
-      true,
+    await mutateCart("Removing the recipe from the cart", () =>
+      client.sendRequest(
+        "POST",
+        "/pages/task/remove-selling-group-from-basket",
+        { payload: { selling_group_id: recipeId } },
+        true,
+      ),
     )
     return { message: "Recipe removed from cart", recipeId }
   },
@@ -832,12 +865,17 @@ const addToCartInputSchema = z.object({
 
 toolRegistry.register({
   name: "picnic_add_to_cart",
-  description: "Add a product to the shopping cart",
+  description:
+    "Add a product to the shopping cart. Not idempotent: each call adds another `count` " +
+    "items. If this fails, call picnic_get_cart to check whether the add landed before retrying.",
   inputSchema: addToCartInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    const cart = await client.cart.addProductToCart(args.productId, args.count)
+    const cart = await mutateCart(`Adding ${args.count} item(s) to cart`, () =>
+      client.cart.addProductToCart(args.productId, args.count),
+    )
     return {
       message: `Added ${args.count} item(s) to cart`,
       cart: filterCartData(cart),
@@ -853,12 +891,18 @@ const removeFromCartInputSchema = z.object({
 
 toolRegistry.register({
   name: "picnic_remove_from_cart",
-  description: "Remove a product from the shopping cart",
+  description:
+    "Remove a product from the shopping cart. Not idempotent: each call removes another " +
+    "`count` items. If this fails, call picnic_get_cart to check whether the removal landed " +
+    "before retrying.",
   inputSchema: removeFromCartInputSchema,
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async (args) => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    const cart = await client.cart.removeProductFromCart(args.productId, args.count)
+    const cart = await mutateCart(`Removing ${args.count} item(s) from cart`, () =>
+      client.cart.removeProductFromCart(args.productId, args.count),
+    )
     return {
       message: `Removed ${args.count} item(s) from cart`,
       cart: filterCartData(cart),
@@ -871,10 +915,11 @@ toolRegistry.register({
   name: "picnic_clear_cart",
   description: "Clear all items from the shopping cart",
   inputSchema: z.object({}),
+  annotations: CART_MUTATION_ANNOTATIONS,
   handler: async () => {
     await ensureClientInitialized()
     const client = getPicnicClient()
-    const cart = await client.cart.clearCart()
+    const cart = await mutateCart("Clearing the cart", () => client.cart.clearCart())
     return {
       message: "Shopping cart cleared",
       cart: filterCartData(cart),

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -88,6 +88,7 @@ function filterCartData(cart: unknown) {
         price?: number
         image_ids?: string[]
         max_count?: number
+        decorators?: Array<{ type?: string; quantity?: number }>
       }>
     }>
     total_count?: number
@@ -104,6 +105,10 @@ function filterCartData(cart: unknown) {
       name: article.name,
       unit: article.unit_quantity,
       price: article.price,
+      // How many of this article are in the cart. Picnic carries it in a QUANTITY decorator
+      // rather than a plain field; without it a caller cannot tell one unit from three, so it
+      // cannot check whether an ambiguous add actually landed (see mutateCart).
+      quantity: article.decorators?.find((d) => d.type === "QUANTITY")?.quantity ?? 1,
       ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
     })),
   }))

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -81,6 +81,7 @@ function filterCartData(cart: unknown) {
       id?: string
       display_price?: number
       price?: number
+      decorators?: Array<{ type?: string; text?: string; id?: string }>
       items?: Array<{
         id?: string
         name?: string
@@ -97,21 +98,34 @@ function filterCartData(cart: unknown) {
     total_savings?: number
   }
 
-  const filteredItems = cartObj.items?.map((orderLine) => ({
-    order_line_id: orderLine.id,
-    price: orderLine.display_price || orderLine.price,
-    articles: orderLine.items?.map((article) => ({
-      product_id: article.id,
-      name: article.name,
-      unit: article.unit_quantity,
-      price: article.price,
-      // How many of this article are in the cart. Picnic carries it in a QUANTITY decorator
-      // rather than a plain field; without it a caller cannot tell one unit from three, so it
-      // cannot check whether an ambiguous add actually landed (see mutateCart).
-      quantity: article.decorators?.find((d) => d.type === "QUANTITY")?.quantity ?? 1,
-      ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
-    })),
-  }))
+  const filteredItems = cartObj.items?.map((orderLine) => {
+    const decorator = (type: string) => orderLine.decorators?.find((d) => d.type === type)
+    // A discounted line otherwise shows only its reduced price, so the saving is visible but
+    // unexplainable — PROMO carries the reason ("15% Rabatt").
+    const promotion = decorator("PROMO")?.text
+    // BASKET_GROUP holds the selling-group id, i.e. the recipe this line came from — the same
+    // id picnic_add_recipe_to_cart takes. Without it there is no way to tell which lines a
+    // recipe contributed, and so no way to undo one with picnic_remove_recipe_from_cart.
+    const recipeId = decorator("BASKET_GROUP")?.id
+
+    return {
+      order_line_id: orderLine.id,
+      price: orderLine.display_price || orderLine.price,
+      ...(promotion && { promotion }),
+      ...(recipeId && { recipe_id: recipeId }),
+      articles: orderLine.items?.map((article) => ({
+        product_id: article.id,
+        name: article.name,
+        unit: article.unit_quantity,
+        price: article.price,
+        // How many of this article are in the cart. Picnic carries it in a QUANTITY decorator
+        // rather than a plain field; without it a caller cannot tell one unit from three, so it
+        // cannot check whether an ambiguous add actually landed (see mutateCart).
+        quantity: article.decorators?.find((d) => d.type === "QUANTITY")?.quantity ?? 1,
+        ...(article.image_ids?.length && { image_id: article.image_ids[0] }),
+      })),
+    }
+  })
 
   return {
     type: cartObj.type,

--- a/src/tools/picnic-tools.ts
+++ b/src/tools/picnic-tools.ts
@@ -100,8 +100,11 @@ function filterCartData(cart: unknown) {
 
   const filteredItems = cartObj.items?.map((orderLine) => {
     const decorator = (type: string) => orderLine.decorators?.find((d) => d.type === type)
-    // A discounted line otherwise shows only its reduced price, so the saving is visible but
-    // unexplainable — PROMO carries the reason ("15% Rabatt").
+    // The label for this line's own discount ("15% Rabatt"). Note the line `price` below is
+    // the price BEFORE this promotion: Picnic deducts promotions at cart level, so the line
+    // prices sum to more than `total_price`, and the difference is `total_savings`. Several
+    // lines can carry different promotions at once, so `total_savings` is the total across
+    // all of them and must not be attributed to any single label.
     const promotion = decorator("PROMO")?.text
     // BASKET_GROUP holds the selling-group id, i.e. the recipe this line came from — the same
     // id picnic_add_recipe_to_cart takes. Without it there is no way to tell which lines a
@@ -866,7 +869,13 @@ toolRegistry.register({
 // Get shopping cart tool
 toolRegistry.register({
   name: "picnic_get_cart",
-  description: "Get the current shopping cart contents with filtered data",
+  description:
+    "Get the current shopping cart contents. Prices are in cents. An order line's `price` is " +
+    "the amount BEFORE that line's own promotion, so the line prices sum to more than the " +
+    "cart's `total_price`; the difference is `total_savings`. A line's `promotion` label " +
+    "(e.g. '15% Rabatt') applies to that line alone — several lines can carry different " +
+    "promotions, so never describe one line's percentage as applying to the cart, and never " +
+    "attribute all of `total_savings` to a single promotion.",
   inputSchema: z.object({}),
   handler: async () => {
     await ensureClientInitialized()

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,18 @@ import { z } from "zod"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { ToolError, ErrorCode, ErrorUtils } from "../types/errors.js"
 
+/**
+ * MCP tool annotations. Hints for the calling model about a tool's side effects —
+ * most importantly whether it is safe to retry after an ambiguous failure.
+ */
+export interface ToolAnnotations {
+  title?: string
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+  openWorldHint?: boolean
+}
+
 export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   name: string
   description: string
@@ -9,6 +21,7 @@ export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   outputSchema?: z.ZodSchema<TOutput>
   handler: (args: TInput) => Promise<TOutput>
   prompts?: string[]
+  annotations?: ToolAnnotations
 }
 
 export interface ToolResult {
@@ -29,6 +42,7 @@ interface StoredToolDefinition {
   outputSchema?: z.ZodSchema<unknown>
   handler: (args: unknown) => Promise<unknown>
   prompts?: string[]
+  annotations?: ToolAnnotations
 }
 
 class ToolRegistry {
@@ -45,6 +59,7 @@ class ToolRegistry {
         name: tool.name,
         description: tool.description,
         inputSchema: zodToJsonSchema(tool.inputSchema),
+        ...(tool.annotations && { annotations: tool.annotations }),
       }
     }
     return definitions
@@ -55,6 +70,7 @@ class ToolRegistry {
       name: tool.name,
       description: tool.description,
       inputSchema: zodToJsonSchema(tool.inputSchema),
+      ...(tool.annotations && { annotations: tool.annotations }),
     }))
   }
 

--- a/test/unit/tools/picnic-cart-tools.test.ts
+++ b/test/unit/tools/picnic-cart-tools.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ToolResult } from "../../../src/tools/registry.js"
+
+const mocks = vi.hoisted(() => ({
+  addProductToCart: vi.fn(),
+  removeProductFromCart: vi.fn(),
+  clearCart: vi.fn(),
+  getCart: vi.fn(),
+  initializePicnicClient: vi.fn(),
+}))
+
+vi.mock("../../../src/utils/picnic-client.js", () => ({
+  getPicnicClient: () => ({
+    cart: {
+      addProductToCart: mocks.addProductToCart,
+      removeProductFromCart: mocks.removeProductFromCart,
+      clearCart: mocks.clearCart,
+      getCart: mocks.getCart,
+    },
+    sendRequest: vi.fn(),
+  }),
+  initializePicnicClient: mocks.initializePicnicClient,
+  saveSession: vi.fn(),
+  verifyPicnic2FACode: vi.fn(),
+}))
+
+function parseToolResult(result: ToolResult) {
+  return JSON.parse(result.content[0].text ?? "")
+}
+
+const emptyCart = { type: "ORDER", id: "cart-1", items: [], total_count: 0 }
+
+describe("picnic cart tools", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await import("../../../src/tools/picnic-tools.js")
+  })
+
+  describe("mutation failures", () => {
+    // Picnic applies the write and renders the cart in one request, so a failure does not
+    // mean the write was rejected. The error has to say so, or the caller retries and
+    // double-applies the change.
+    it("warns that the cart may have changed when add_to_cart fails", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.addProductToCart.mockRejectedValue(
+        new Error("Client version is required to preview the cart page"),
+      )
+
+      await expect(
+        toolRegistry.executeTool("picnic_add_to_cart", { productId: "s1032332", count: 1 }),
+      ).rejects.toThrow(/cart may still have been modified/i)
+    })
+
+    it("points the caller at picnic_get_cart rather than a retry", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.removeProductFromCart.mockRejectedValue(new Error("boom"))
+
+      await expect(
+        toolRegistry.executeTool("picnic_remove_from_cart", { productId: "s1", count: 1 }),
+      ).rejects.toThrow(/picnic_get_cart/)
+    })
+
+    it("preserves the upstream error message", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.clearCart.mockRejectedValue(new Error("upstream detail"))
+
+      await expect(toolRegistry.executeTool("picnic_clear_cart", {})).rejects.toThrow(
+        /upstream detail/,
+      )
+    })
+  })
+
+  describe("successful mutations", () => {
+    it("returns the filtered cart on success", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.addProductToCart.mockResolvedValue(emptyCart)
+
+      const result = await toolRegistry.executeTool("picnic_add_to_cart", {
+        productId: "s1032332",
+        count: 2,
+      })
+
+      expect(mocks.addProductToCart).toHaveBeenCalledWith("s1032332", 2)
+      expect(parseToolResult(result).message).toBe("Added 2 item(s) to cart")
+    })
+
+    it("does not retry the mutation itself", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      mocks.addProductToCart.mockRejectedValue(new Error("nope"))
+
+      await expect(
+        toolRegistry.executeTool("picnic_add_to_cart", { productId: "s1", count: 1 }),
+      ).rejects.toThrow()
+      expect(mocks.addProductToCart).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("annotations", () => {
+    it("marks cart mutations as non-idempotent and destructive", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      const list = toolRegistry.getToolsList() as Array<{
+        name: string
+        annotations?: Record<string, boolean>
+      }>
+
+      for (const name of [
+        "picnic_add_to_cart",
+        "picnic_remove_from_cart",
+        "picnic_clear_cart",
+        "picnic_add_recipe_to_cart",
+        "picnic_remove_recipe_from_cart",
+      ]) {
+        const tool = list.find((t) => t.name === name)
+        expect(tool, `${name} should be registered`).toBeDefined()
+        expect(tool?.annotations, `${name} should carry annotations`).toMatchObject({
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+        })
+      }
+    })
+
+    it("leaves read-only tools unannotated", async () => {
+      const { toolRegistry } = await import("../../../src/tools/registry.js")
+      const list = toolRegistry.getToolsList() as Array<{
+        name: string
+        annotations?: Record<string, boolean>
+      }>
+
+      expect(list.find((t) => t.name === "picnic_get_cart")?.annotations).toBeUndefined()
+    })
+  })
+})

--- a/test/unit/tools/picnic-cart-tools.test.ts
+++ b/test/unit/tools/picnic-cart-tools.test.ts
@@ -171,6 +171,61 @@ describe("picnic_get_cart quantities", () => {
     expect(cart.items[0].articles[0].quantity).toBe(2)
   })
 
+  // A discounted line shows only its reduced price, so without PROMO the saving is visible
+  // but unexplainable.
+  it("surfaces the PROMO decorator as the reason for a discount", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      items: [
+        {
+          id: "1869",
+          display_price: 1272,
+          decorators: [
+            { type: "PROMO", text: "15% Rabatt" },
+            { type: "PRICE", display_price: 1272 },
+          ],
+          items: [{ id: "s1", name: "Durex", price: 749 }],
+        },
+      ],
+      total_savings: 294,
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0].promotion).toBe("15% Rabatt")
+    expect(cart.items[0].price).toBe(1272)
+    expect(cart.total_savings).toBe(294)
+  })
+
+  // BASKET_GROUP is the selling-group id, so it identifies which recipe put this line in the
+  // cart — the id picnic_remove_recipe_from_cart needs to undo it.
+  it("surfaces BASKET_GROUP as the originating recipe id", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      items: [
+        {
+          id: "1870",
+          price: 255,
+          decorators: [{ type: "BASKET_GROUP", id: "6866314281719e5205f82666" }],
+          items: [{ id: "s2", name: "Aubergine", price: 255 }],
+        },
+      ],
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0].recipe_id).toBe("6866314281719e5205f82666")
+  })
+
+  it("omits promotion and recipe_id when the line carries no decorators", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      items: [{ id: "1", price: 169, items: [{ id: "s3", name: "Bananen", price: 169 }] }],
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0]).not.toHaveProperty("promotion")
+    expect(cart.items[0]).not.toHaveProperty("recipe_id")
+  })
+
   it("defaults to 1 when no QUANTITY decorator is present", async () => {
     const { toolRegistry } = await import("../../../src/tools/registry.js")
     mocks.getCart.mockResolvedValue({

--- a/test/unit/tools/picnic-cart-tools.test.ts
+++ b/test/unit/tools/picnic-cart-tools.test.ts
@@ -131,3 +131,55 @@ describe("picnic cart tools", () => {
     })
   })
 })
+
+describe("picnic_get_cart quantities", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await import("../../../src/tools/picnic-tools.js")
+  })
+
+  // Without this the caller cannot verify whether an ambiguous add landed once or twice,
+  // which is exactly what the mutation error message tells it to go and check.
+  it("surfaces the QUANTITY decorator as a quantity field", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      type: "ORDER",
+      id: "shopping_cart",
+      total_count: 2,
+      items: [
+        {
+          type: "ORDER_LINE",
+          id: "1871",
+          price: 510,
+          items: [
+            {
+              id: "s1032332",
+              name: "Frosch Cremeseife",
+              unit_quantity: "500ml",
+              price: 255,
+              decorators: [
+                { type: "QUANTITY", quantity: 2 },
+                { type: "UNIT_QUANTITY", unit_quantity_text: "500ml" },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0].articles[0].quantity).toBe(2)
+  })
+
+  it("defaults to 1 when no QUANTITY decorator is present", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      type: "ORDER",
+      id: "shopping_cart",
+      items: [{ id: "1", price: 255, items: [{ id: "s1", name: "x", price: 255 }] }],
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items[0].articles[0].quantity).toBe(1)
+  })
+})

--- a/test/unit/tools/picnic-cart-tools.test.ts
+++ b/test/unit/tools/picnic-cart-tools.test.ts
@@ -196,6 +196,35 @@ describe("picnic_get_cart quantities", () => {
     expect(cart.total_savings).toBe(294)
   })
 
+  // Several lines can carry different promotions at once, and total_savings is the sum across
+  // all of them — so a single label must never be readable as the cart-wide discount.
+  it("keeps each promotion scoped to its own line", async () => {
+    const { toolRegistry } = await import("../../../src/tools/registry.js")
+    mocks.getCart.mockResolvedValue({
+      items: [
+        { id: "a", price: 1498, decorators: [{ type: "PROMO", text: "15% Rabatt" }], items: [] },
+        { id: "b", price: 179, decorators: [{ type: "PROMO", text: "10% Rabatt" }], items: [] },
+        { id: "c", price: 249, decorators: [{ type: "PROMO", text: "20% Rabatt" }], items: [] },
+        { id: "d", price: 169, items: [] },
+      ],
+      total_price: 1801,
+      total_savings: 294,
+    })
+
+    const cart = parseToolResult(await toolRegistry.executeTool("picnic_get_cart", {}))
+    expect(cart.items.map((i: { promotion?: string }) => i.promotion)).toEqual([
+      "15% Rabatt",
+      "10% Rabatt",
+      "20% Rabatt",
+      undefined,
+    ])
+    // The cart-level total is not any one line's saving.
+    expect(cart.total_savings).toBe(294)
+    // Line prices are pre-discount, so they sum above total_price by exactly total_savings.
+    const sum = cart.items.reduce((a: number, i: { price: number }) => a + i.price, 0)
+    expect(sum - cart.total_price).toBe(cart.total_savings)
+  })
+
   // BASKET_GROUP is the selling-group id, so it identifies which recipe put this line in the
   // cart — the id picnic_remove_recipe_from_cart needs to undo it.
   it("surfaces BASKET_GROUP as the originating recipe id", async () => {


### PR DESCRIPTION
> **Stacks on #56.** Both change the same `filterCartData()` order-line mapping, so this
> cannot sit on `main` independently. Review #56 first; the diff here shows its commits too
> until it lands, after which this reduces to the last two.

`picnic_get_cart` discards Picnic's order-line decorators, dropping two pieces of
information that have no other source in the API response.

## Problem

**1. A promotion has no name.** The cart reports `total_savings` but nothing saying what was
discounted or why. A line carries `{"type":"PROMO","text":"15% Rabatt"}`; none of it reached
the caller.

**2. A recipe's lines are unidentifiable.** `picnic_add_recipe_to_cart` posts a
`selling_group_id`, and Picnic tags every line it created with
`{"type":"BASKET_GROUP","id":"<that id>"}`. Dropping it means there is no way to see which
lines a recipe contributed — so `picnic_remove_recipe_from_cart`, which already exists, has
no way to discover the id for a recipe already in the cart. It can only be called with an id
the caller happens to still be holding.

## Reproduce

```
picnic_get_cart()
```

against a cart with a promotion and a recipe. Every order line comes back as
`{order_line_id, price, articles}` — the `decorators` array is dropped wholesale.

## Fix

Read two decorators per order line:

- `promotion` from `PROMO` — the label.
- `recipe_id` from `BASKET_GROUP` — the selling-group id, so recipe-contributed lines are
  identifiable and removable.

`PRICE` and `UNIT_QUANTITY` are deliberately not surfaced; they duplicate the existing
`price` and `unit`. `PRICE_STYLE` is a colour.

### Promotion arithmetic is stated, not implied

This is the part worth reviewing. Picnic deducts promotions at **cart** level, so an order
line's `price` is the amount *before* its own promotion, and several lines can carry
different promotions at once. In the cart used for testing, three lines carry 15%, 10% and
20%; the line prices sum to 3832 against a `total_price` of 3538; and the 294 difference is
exactly `total_savings` — an aggregate across all three, not the 15% one.

Surfacing a per-line percentage next to a cart-level savings total is easy to misreport as
"you saved 15% on your cart". `picnic_get_cart`'s description now states the relationship
explicitly so a model cannot draw that conclusion, and a test pins the
`sum(lines) - total_price == total_savings` invariant.

No per-line saving amount is computed: it would mean parsing a localised percentage string
and guessing Picnic's rounding. The label is passed through as a label.

## Testing

`npm test` — 259 passing, 4 new tests covering the promotion label, the recipe id, omission
when a line has no decorators, and the multi-promotion scoping invariant.
`npm run typecheck`, `npm run lint`, `npm run build` clean.

Verified against a live account (DE) over stdio: three concurrent promotions surface
correctly, five order lines resolve to one shared `recipe_id`, and the savings invariant
holds exactly on real data.

## Credit

The idea of surfacing cart decorators comes from #33 by @gmrizzo, which has been open since
April. That PR compacts decorators at the order-line level only, so it does not surface the
article-level `QUANTITY` handled in #56 — the two are complementary. This takes the
decorator work alone and leaves #33's dependency downgrade and `FR` removal out, both of
which have been overtaken by `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
